### PR TITLE
Designing "Why use Mixit?" section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import { Hero } from "@/components/sections/Hero";
 import Features from "@/components/sections/Features";
+import WhyUseMixit from "@/components/sections/WhyUseMixit";
 
 export default function Index() {
   return (
     <>
       <Hero />
       <Features />
+      <WhyUseMixit />
     </>
   );
 }

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -3,4 +3,5 @@ export { default as BlenderIcon } from "./blender-icon.svg";
 export { default as PickAndMixIcon } from "./pick-and-mix-icon.svg";
 export { default as TimeMachineIcon } from "./time-machine-icon.svg";
 export { default as QueueIcon } from "./queue-icon.svg";
+export { default as BarChartIcon } from "./bar-chart.svg";
 export { default as DiscSVG } from "./disc.svg";

--- a/src/components/base/Section.tsx
+++ b/src/components/base/Section.tsx
@@ -2,11 +2,11 @@ import { cn } from "@/utils/helpers";
 import { VariantProps, cva } from "class-variance-authority";
 import React, { FC } from "react";
 
-const sectionVariants = cva("mx-auto", {
+const sectionVariants = cva("", {
   variants: {
     level: {
       section: "",
-      main: "u-container",
+      main: "u-container mx-auto",
       article: "",
       aside: "",
       header: "",
@@ -20,11 +20,11 @@ const sectionVariants = cva("mx-auto", {
       dialog: "",
     },
     grid: {
-      true: "u-grid",
+      true: "u-grid auto-rows-min place-content-center",
       false: "",
     },
     padding: {
-      true: "",
+      true: "px-32 pb-80 pt-64 lg:px-64 lg:py-80",
       false: "",
     },
     sticky: {
@@ -34,8 +34,9 @@ const sectionVariants = cva("mx-auto", {
   },
   defaultVariants: {
     level: "section",
-    grid: true,
+    grid: false,
     sticky: false,
+    padding: false,
   },
 });
 
@@ -64,7 +65,7 @@ interface SectionProps
 const Section: FC<SectionProps> = ({
   level = "section",
   grid = false,
-  padding = true,
+  padding = false,
   sticky = false,
   className,
   ...props

--- a/src/components/base/Text.tsx
+++ b/src/components/base/Text.tsx
@@ -6,10 +6,11 @@ import React, { FC } from "react";
 const textVariants = cva("font-normal leading-[24px]", {
   variants: {
     level: {
-      p: "text-base",
+      p: "max-w-prose text-base",
       small: "text-sm",
       strong: "font-bold",
       u: "inline-block font-bold text-accent underline underline-offset-4 hover:cursor-pointer",
+      figcaption: "max-w-prose",
 
       /**  This is left intentionally blank to provide client abstraction
        *   for the HTML span element while giving access to brand

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -36,7 +36,7 @@ function Features() {
         }}
         bgColor={"secondary"}
         flexDirection={"col"}
-        className="mb-16 min-w-[75%] snap-start items-center gap-16 px-24 py-16 lg:min-w-fit lg:snap-none"
+        className="min-w-[75%] snap-start items-center gap-16 px-24 py-16 lg:min-w-fit lg:snap-none"
       />
     );
   });
@@ -44,11 +44,12 @@ function Features() {
   return (
     <Section
       grid
-      className="u-container min-h-screen auto-rows-min place-content-center overflow-hidden px-32 pb-80 pt-64 md:grid-rows-none lg:px-32 lg:py-80"
+      padding
+      className="u-container mx-auto min-h-screen overflow-hidden md:grid-rows-none"
     >
       <Section
         level="figure"
-        className="col-span-full row-start-2 inline-flex  w-full snap-x snap-mandatory scroll-px-16 flex-row gap-4 overflow-x-auto lg:col-span-6 lg:row-start-1 lg:grid lg:grid-cols-2  lg:grid-rows-[auto] lg:overflow-x-hidden"
+        className="col-span-full row-start-2 inline-flex w-full snap-x snap-mandatory scroll-px-16 flex-row gap-4 overflow-x-auto lg:col-span-6 lg:row-start-1 lg:grid lg:grid-cols-2 lg:grid-rows-[auto]  lg:gap-8 lg:overflow-x-hidden xl:gap-24"
       >
         {appCards}
       </Section>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -13,7 +13,8 @@ export function Hero({}) {
       <Section
         level="main"
         grid
-        className="lg:pl-100 min-h-screen w-full auto-rows-min  content-center items-end overflow-hidden px-32 pb-80 md:grid-rows-none lg:px-32 lg:pb-80"
+        padding
+        className="min-h-screen w-full auto-rows-min content-center items-end overflow-hidden md:grid-rows-none"
       >
         {/* Content */}
         <div className="col-span-full row-start-2 lg:col-span-6 lg:row-start-1">

--- a/src/components/sections/WhyUseMixit.tsx
+++ b/src/components/sections/WhyUseMixit.tsx
@@ -14,21 +14,19 @@ const WhyUseMixit: React.FC = () => (
     padding
     className="u-container mx-auto min-h-screen auto-rows-min place-content-center"
   >
-    <div className="u-grid col-span-full mb-24">
-      <div className="col-span-full lg:col-span-6 lg:mb-32">
-        <div className="mb-16">
-          <Pretitle>Why use Mixit</Pretitle>
-          <Heading>Enjoy a new, true shuffle</Heading>
-        </div>
-        <Text>Spotify's shuffle can repeat songs, even in big playlists.</Text>
+    <div className="col-span-full mb-24 lg:col-span-6 lg:mb-32">
+      <div className="mb-16">
+        <Pretitle>Why use Mixit</Pretitle>
+        <Heading>Enjoy a new, true shuffle</Heading>
       </div>
-      <div className="col-span-full col-start-7 hidden lg:flex lg:flex-row lg:justify-center">
-        <Disc
-          className="h-full w-auto"
-          ringColor="accent-5"
-          spin="counterClockwise"
-        />
-      </div>
+      <Text>Spotify's shuffle can repeat songs, even in big playlists.</Text>
+    </div>
+    <div className="col-span-full col-start-7 row-start-1 row-end-2 hidden lg:flex lg:flex-row lg:justify-end">
+      <Disc
+        className="h-[130%] w-auto xl:h-[160%]"
+        ringColor="accent-5"
+        spin="counterClockwise"
+      />
     </div>
 
     <Section

--- a/src/components/sections/WhyUseMixit.tsx
+++ b/src/components/sections/WhyUseMixit.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Section } from "../base/Section";
+import { Pretitle } from "@/components/base/Pretitle";
+import { Heading } from "../base/Heading";
+import { Text } from "../base/Text";
+import { HeadingLevels, TextLevels } from "@/types/text";
+import { BarChartIcon } from "@/assets/svg";
+import { QueueIcon } from "@/assets/svg";
+import { Disc } from "../decorations/Disc";
+
+const WhyUseMixit: React.FC = () => (
+  <Section
+    grid
+    className="u-container min-h-screen auto-rows-min place-content-center px-32 py-64"
+  >
+    <div className="col-span-full mb-24">
+      <div className="mb-16">
+        <Pretitle>Why use Mixit</Pretitle>
+        <Heading>Enjoy a new, true shuffle</Heading>
+      </div>
+      <Text>Spotify's shuffle can repeat songs, even in big playlists.</Text>
+    </div>
+    <Section
+      level="figure"
+      className="col-span-full flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20"
+    >
+      <div className="mb-8 flex min-h-[30px] max-w-[30px] flex-col items-center justify-center rounded-[8px] bg-secondary">
+        <BarChartIcon className="h-auto min-h-[20px] fill-accent-1" />
+      </div>
+      <Heading level={HeadingLevels.h3} className="pb-4 uppercase">
+        How Mixit is different
+      </Heading>
+      <Text level={TextLevels.figcaption} textColor="gray">
+        Mixit uses the Fisher-Yates shuffling algorithm to ensure a truly random
+        shuffle every time.
+      </Text>
+    </Section>
+    <div className="col-start-1 col-end-3">
+      <Disc className="absolute -left-[30%] h-[50vw] w-[50vw]" />
+    </div>
+    <Section
+      level="figure"
+      className="col-span-full col-start-3 flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20"
+    >
+      <div className="mb-8 flex min-h-[30px] max-w-[30px] flex-col items-center justify-center rounded-[8px] bg-secondary">
+        <QueueIcon className="h-auto min-h-[20px] fill-accent-2" />
+      </div>
+      <Heading level={HeadingLevels.h3} className="pb-4 uppercase">
+        Take control of your queue
+      </Heading>
+      <Text level={TextLevels.figcaption} textColor="gray">
+        Tired of the same songs? It's time to mix things up.
+      </Text>
+    </Section>
+  </Section>
+);
+WhyUseMixit.displayName = "Reasons Section";
+
+export default WhyUseMixit;

--- a/src/components/sections/WhyUseMixit.tsx
+++ b/src/components/sections/WhyUseMixit.tsx
@@ -11,18 +11,29 @@ import { Disc } from "../decorations/Disc";
 const WhyUseMixit: React.FC = () => (
   <Section
     grid
-    className="u-container min-h-screen auto-rows-min place-content-center px-32 py-64"
+    padding
+    className="u-container mx-auto min-h-screen auto-rows-min place-content-center"
   >
-    <div className="col-span-full mb-24">
-      <div className="mb-16">
-        <Pretitle>Why use Mixit</Pretitle>
-        <Heading>Enjoy a new, true shuffle</Heading>
+    <div className="u-grid col-span-full mb-24">
+      <div className="col-span-full lg:col-span-6 lg:mb-32">
+        <div className="mb-16">
+          <Pretitle>Why use Mixit</Pretitle>
+          <Heading>Enjoy a new, true shuffle</Heading>
+        </div>
+        <Text>Spotify's shuffle can repeat songs, even in big playlists.</Text>
       </div>
-      <Text>Spotify's shuffle can repeat songs, even in big playlists.</Text>
+      <div className="col-span-full col-start-7 hidden lg:flex lg:flex-row lg:justify-center">
+        <Disc
+          className="h-full w-auto"
+          ringColor="accent-5"
+          spin="counterClockwise"
+        />
+      </div>
     </div>
+
     <Section
       level="figure"
-      className="col-span-full flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20"
+      className="col-span-full flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20 lg:col-start-5 lg:self-end"
     >
       <div className="mb-8 flex min-h-[30px] max-w-[30px] flex-col items-center justify-center rounded-[8px] bg-secondary">
         <BarChartIcon className="h-auto min-h-[20px] fill-accent-1" />
@@ -35,12 +46,16 @@ const WhyUseMixit: React.FC = () => (
         shuffle every time.
       </Text>
     </Section>
-    <div className="col-start-1 col-end-3">
-      <Disc className="absolute -left-[30%] h-[50vw] w-[50vw]" />
+    <div className="col-start-1 col-end-3 row-start-3 lg:col-span-4 lg:row-span-2 lg:row-start-2">
+      <Disc
+        ringColor="accent-4"
+        className="absolute -left-[30%] h-[50vw] w-[50vw] lg:static lg:-left-0 lg:h-auto lg:w-full lg:max-w-[700px]"
+      />
     </div>
+
     <Section
       level="figure"
-      className="col-span-full col-start-3 flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20"
+      className="col-span-full col-start-3 flex h-fit flex-col border-l-[3px] border-[#CACACA]/10 py-16 ps-20 lg:col-start-6"
     >
       <div className="mb-8 flex min-h-[30px] max-w-[30px] flex-col items-center justify-center rounded-[8px] bg-secondary">
         <QueueIcon className="h-auto min-h-[20px] fill-accent-2" />

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -13,6 +13,7 @@ export enum TextLevels {
   small = "small",
   strong = "strong",
   u = "u",
+  figcaption = "figcaption",
   mark = "mark",
   summary = "summary",
   blockquote = "blockquote",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,7 @@ module.exports = {
         "accent-5": "#F28FFF",
       },
       spacing: {
+        4: "4px",
         8: "8px",
         12: "12px",
         16: "16px",


### PR DESCRIPTION
Adding the "Why use Mixit?" section, responsive for mobile, tablet, and desktop devices.

This is what the layout section looks like on various devices:

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
Desktop| 1440x1020 | ![Why-Use-Section-Desktop](https://github.com/mianjoto/mixit/assets/78712025/225ccf79-f5a1-4b5f-a468-9a4c3523903a)
iPhone 12 Pro | 390x844 | ![Why-Use-Section-iPhone-12-Pro](https://github.com/mianjoto/mixit/assets/78712025/bdcae962-b2f4-4d36-8eb1-f77d0c59714a)
iPad Air (Portrait) | 820x1180 | ![Why-Use-Section--iPad-Air-Portrait](https://github.com/mianjoto/mixit/assets/78712025/b26e3727-2aa1-4564-acd7-7b17af6ddf5b)
iPad Air (Landscape) | 1180x820 | ![Why-Use-Section-iPad-Air-Landscape](https://github.com/mianjoto/mixit/assets/78712025/fc24f945-2ae1-4bee-95d2-d5c68dd2bf7d)



