### PR TITLE
Fixing mobile viewport

### DIFF
--- a/src/components/base/Section.tsx
+++ b/src/components/base/Section.tsx
@@ -23,8 +23,16 @@ const sectionVariants = cva("", {
       true: "u-grid auto-rows-min place-content-center",
       false: "",
     },
+    container: {
+      true: "u-container mx-auto auto-rows-min place-content-center overflow-hidden",
+      false: "",
+    },
     padding: {
-      true: "px-32 pb-80 pt-64 lg:px-64 lg:py-80",
+      true: "px-32 py-64 lg:px-64 lg:py-80",
+      false: "",
+    },
+    fitScreenHeight: {
+      true: "min-h-screen",
       false: "",
     },
     sticky: {
@@ -35,8 +43,10 @@ const sectionVariants = cva("", {
   defaultVariants: {
     level: "section",
     grid: false,
-    sticky: false,
+    container: false,
     padding: false,
+    fitScreenHeight: false,
+    sticky: false,
   },
 });
 
@@ -65,7 +75,9 @@ interface SectionProps
 const Section: FC<SectionProps> = ({
   level = "section",
   grid = false,
+  container = false,
   padding = false,
+  fitScreenHeight = false,
   sticky = false,
   className,
   ...props
@@ -75,7 +87,15 @@ const Section: FC<SectionProps> = ({
   return (
     <SectionElement
       className={cn(
-        sectionVariants({ level, grid, padding, sticky, className })
+        sectionVariants({
+          level,
+          grid,
+          container,
+          padding,
+          sticky,
+          fitScreenHeight,
+          className,
+        })
       )}
       {...props}
     >

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -42,7 +42,13 @@ function Features() {
   });
 
   return (
-    <Section grid padding container className="md:grid-rows-none">
+    <Section
+      grid
+      padding
+      container
+      fitScreenHeight
+      className="md:grid-rows-none"
+    >
       <Section
         level="figure"
         className="col-span-full row-start-2 inline-flex w-full snap-x snap-mandatory scroll-px-16 flex-row gap-4 overflow-x-auto lg:col-span-6 lg:row-start-1 lg:grid lg:grid-cols-2 lg:grid-rows-[auto]  lg:gap-8 lg:overflow-x-hidden xl:gap-24"

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -42,11 +42,7 @@ function Features() {
   });
 
   return (
-    <Section
-      grid
-      padding
-      className="u-container mx-auto min-h-screen overflow-hidden md:grid-rows-none"
-    >
+    <Section grid padding container className="md:grid-rows-none">
       <Section
         level="figure"
         className="col-span-full row-start-2 inline-flex w-full snap-x snap-mandatory scroll-px-16 flex-row gap-4 overflow-x-auto lg:col-span-6 lg:row-start-1 lg:grid lg:grid-cols-2 lg:grid-rows-[auto]  lg:gap-8 lg:overflow-x-hidden xl:gap-24"

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -15,6 +15,7 @@ export function Hero({}) {
         grid
         padding
         container
+        fitScreenHeight
         className="items-end md:grid-rows-none"
       >
         {/* Content */}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,7 +14,8 @@ export function Hero({}) {
         level="main"
         grid
         padding
-        className="min-h-screen w-full auto-rows-min content-center items-end overflow-hidden md:grid-rows-none"
+        container
+        className="items-end md:grid-rows-none"
       >
         {/* Content */}
         <div className="col-span-full row-start-2 lg:col-span-6 lg:row-start-1">

--- a/src/components/sections/WhyUseMixit.tsx
+++ b/src/components/sections/WhyUseMixit.tsx
@@ -9,11 +9,7 @@ import { QueueIcon } from "@/assets/svg";
 import { Disc } from "../decorations/Disc";
 
 const WhyUseMixit: React.FC = () => (
-  <Section
-    grid
-    padding
-    className="u-container mx-auto min-h-screen auto-rows-min place-content-center"
-  >
+  <Section grid padding container>
     <div className="col-span-full mb-24 lg:col-span-6 lg:mb-32">
       <div className="mb-16">
         <Pretitle>Why use Mixit</Pretitle>

--- a/src/components/sections/WhyUseMixit.tsx
+++ b/src/components/sections/WhyUseMixit.tsx
@@ -9,7 +9,7 @@ import { QueueIcon } from "@/assets/svg";
 import { Disc } from "../decorations/Disc";
 
 const WhyUseMixit: React.FC = () => (
-  <Section grid padding container>
+  <Section grid padding container fitScreenHeight>
     <div className="col-span-full mb-24 lg:col-span-6 lg:mb-32">
       <div className="mb-16">
         <Pretitle>Why use Mixit</Pretitle>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,15 @@ module.exports = {
         "disc-spin-cw": "spin 45s linear infinite",
         "disc-spin-ccw": "spin 45s linear infinite reverse",
       },
+      minHeight: {
+        screen: ["100vh /* fallback for Opera, IE and etc. */", "100svh"],
+      },
+      transitionProperty: {
+        height: "height, min-height",
+      },
+      height: {
+        screen: ["100vh /* fallback for Opera, IE and etc. */", "100svh"],
+      },
     },
   },
   plugins: [require("@shrutibalasa/tailwind-grid-auto-fit")],


### PR DESCRIPTION
I fixed the mobile viewport issue. Before, I was using TailwindCSS's built in `min-h-screen` utility class for each major section of content, which applies `min-height: 100vh` to each `<section>` element. This works as expected on desktop but leads to issues on mobile devices, since the `vh` unit returns the true height of the device in pixels. 

Many mobile browsers add browser elements like an search or address bar. The `vh` calculation does not pay respect to this difference, which means that `100vh` actually stretches into the address bar and other mobile browser elements. This often leads to issues where elements might be hidden by the browser elements on mobile devices.

CSS has recently added small, large, and dynamic viewport units that return heights and widths that pay mind to a device's browser elements. In other words, if a mobile browser's expanded address bar takes up 100px from the anticipated `100vh` value of 800px, the `svh` (small viewport height) unit will do this calculation automatically to result in (800px - 100px = 700px).

You can read more about browser support for small, large, and dynamic viewport units [here](https://caniuse.com/viewport-unit-variants). Since not all browsers support these units, I have a fallback CSS declaration of `min-height: 100vh` wherever I use `min-height: 100svh/lvh/dvh`.

---
I used these units to fix bad web responsiveness practices. Before, I manually added a fixed amount of bottom padding for each section to push the content up away from the address bar on the bottom. There are a few reasons why this was not a great idea: 
+ Not all mobile devices have browser elements on the bottom -- many have their elements on the top. Adding bottom padding would have forced the section further into their browser elements.
+ Choosing a fixed bottom padding value rather than a responsive value may lead to issues between devices and mobile browsers

This is what the site used to look like with the extra bottom padding on an iPhone 13:
![different-top-bottom-padding-100vh](https://github.com/mianjoto/mixit/assets/78712025/c532e24c-0c66-4aad-a4c3-2199fa93b957)

While it works on this specific device, this design is bound to break when swapping browsers or devices.

In this branch, I extended the tailwind `height` and `minHeight` properties to use `svh`. When using `min-height: 100svh` and even padding on top and bottom, this is what the site looks like on the same iPhone 13:

![even-y-padding-100dvh-final](https://github.com/mianjoto/mixit/assets/78712025/0ae30128-c6bb-4c4a-9dc4-1d1796c316d4)

While there may not appear to be a large difference on this specific device, this change will allow Mixit to be viewed more consistently across devices.

This is what Mixit looks like with a top address bar on an iPhone 13 in Safari.
![top-address-bar-100svh](https://github.com/mianjoto/mixit/assets/78712025/7c10c52b-bed0-4db4-a002-a311dc112e06)
