### PR TITLE
Designing cta section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Hero } from "@/components/sections/Hero";
 import Features from "@/components/sections/Features";
 import WhyUseMixit from "@/components/sections/WhyUseMixit";
+import CallToAction from "@/components/sections/CallToAction";
 
 export default function Index() {
   return (
@@ -8,6 +9,7 @@ export default function Index() {
       <Hero />
       <Features />
       <WhyUseMixit />
+      <CallToAction />
     </>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import Link from "next/link";
 
 const buttonVariants = cva(
-  "h-fit w-fit select-none rounded-[30px] font-bold uppercase transition duration-200 ease-in-out focus:ring",
+  "h-fit w-fit select-none rounded-[30px] text-center font-bold uppercase transition duration-200 ease-in-out focus:ring",
   {
     variants: {
       variant: {

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Section } from "../base/Section";
+import { Heading } from "../base/Heading";
+import { Text } from "../base/Text";
+import { Button } from "../Button";
+
+const CallToAction: React.FC = () => (
+  <Section
+    padding
+    container
+    fitScreenHeight
+    className="flex flex-col place-content-center items-center"
+  >
+    <div className="mb-32 lg:mb-64">
+      <Heading
+        textColor="primary"
+        alignment="center"
+        className="mb-[10px] sm:mb-16 lg:mb-24"
+      >
+        Ready to shuffle for real?
+      </Heading>
+      <Text alignment="center" className="max-w-full">
+        Click below to start mixing your favorites into something inspiring.
+      </Text>
+    </div>
+    <Button size="cta" href="/dashboard">
+      Start mixing
+    </Button>
+  </Section>
+);
+CallToAction.displayName = "Call To Action Section";
+
+export default CallToAction;


### PR DESCRIPTION
Adding the call to action section, responsive for mobile, tablet, and desktop devices.

This is what the layout section looks like on various devices:

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
Desktop| 1440x1020 | ![localhost_3000_ (1)](https://github.com/mianjoto/mixit/assets/78712025/14dc5b8e-4966-4d04-b9dc-dee92fc7004e)
iPhone 12 Pro | 390x844 | ![localhost_3000_ (2)](https://github.com/mianjoto/mixit/assets/78712025/316b2bce-95ef-4912-a57b-9a6ba55b89ba)
iPad Air (Portrait) | 820x1180 | ![localhost_3000_(iPad Air)](https://github.com/mianjoto/mixit/assets/78712025/5ebe2c4a-6a08-4c40-97a7-d3f6a09d80ee)
iPad Air (Landscape) | 1180x820 | ![localhost_3000_(iPad Air) (1)](https://github.com/mianjoto/mixit/assets/78712025/35a4e8c0-b21b-4312-a123-61e116b567da)

