### PR TITLE
Designing navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@total-typescript/ts-reset": "^0.4.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "framer-motion": "^10.16.2",
     "next": "^13.4.12",
     "postcss": "8.4.27",
     "react": "18.2.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,12 @@ import WhyUseMixit from "@/components/sections/WhyUseMixit";
 import CallToAction from "@/components/sections/CallToAction";
 import Footer from "@/components/sections/Footer";
 import Separator from "@/components/Separator";
+import Navbar from "@/components/sections/Navbar";
 
 export default function Index() {
   return (
     <>
+      <Navbar />
       <Hero />
       <Features />
       <WhyUseMixit />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import Link from "next/link";
 
 const buttonVariants = cva(
-  "h-fit w-fit select-none rounded-[30px] text-center font-bold uppercase transition duration-200 ease-in-out focus:ring",
+  "h-fit w-fit select-none rounded-[30px] text-center font-bold uppercase leading-normal transition duration-200 ease-in-out focus:ring lg:leading-none",
   {
     variants: {
       variant: {
@@ -15,7 +15,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "px-24 py-8 text-base tracking-tight",
-        cta: "w-full px-56 py-12 text-lg tracking-tight lg:w-fit",
+        cta: "w-full px-32 py-12 text-lg tracking-tight lg:w-fit lg:px-56 lg:text-[32px]",
       },
     },
     defaultVariants: {

--- a/src/components/MixitHomeLogo.tsx
+++ b/src/components/MixitHomeLogo.tsx
@@ -1,0 +1,22 @@
+import React, { HTMLAttributes } from "react";
+import { MixitLogo } from "@/assets/mixit";
+import Link from "next/link";
+
+interface MixitIconProps extends React.SVGProps<SVGSVGElement> {}
+
+const MixitHomeLogo: React.FC<MixitIconProps> = (props: MixitIconProps) => {
+  return (
+    <Link href="/" aria-label="Mixit" className="w-fit">
+      <MixitLogo
+        {...props}
+        width={props.width ? props.width : "70px"}
+        height={props.height ? props.width : "auto"}
+        fill="#fff"
+        className="inline"
+      />
+    </Link>
+  );
+};
+MixitHomeLogo.displayName = "Mixit";
+
+export default MixitHomeLogo;

--- a/src/components/base/LinkText.tsx
+++ b/src/components/base/LinkText.tsx
@@ -2,30 +2,30 @@ import React, { FC } from "react";
 import { Text, TextProps } from "./Text";
 import Link, { LinkProps } from "next/link";
 import { Link as LinkType } from "@/types/links";
-import { TextLevels } from "@/types/text";
+import { HeadingLevels, TextLevels } from "@/types/text";
 import { cn } from "@/utils/helpers";
 import { Heading, HeadingProps } from "./Heading";
 
 interface LinkTextProps {
   link: LinkType;
   textProps?: TextProps | HeadingProps;
+  isHeading?: boolean;
   className?: string;
 }
 
 const LinkText: FC<LinkTextProps> = ({
   link = { href: "/404", text: "MISSING LINK, PLEASE FIX :)" },
   textProps = { level: TextLevels.span },
+  isHeading = false,
   className,
   ...props
 }: LinkTextProps) => {
-  const isText: boolean = (textProps as TextProps).level !== undefined;
-
   return (
     <Link {...props} className={cn("w-fit", className)} href={link.href}>
-      {isText ? (
-        <Text {...(textProps as TextProps)}>{link.text}</Text>
-      ) : (
+      {isHeading ? (
         <Heading {...(textProps as HeadingProps)}>{link.text}</Heading>
+      ) : (
+        <Text {...(textProps as TextProps)}>{link.text}</Text>
       )}
     </Link>
   );

--- a/src/components/base/LinkText.tsx
+++ b/src/components/base/LinkText.tsx
@@ -4,27 +4,29 @@ import Link, { LinkProps } from "next/link";
 import { Link as LinkType } from "@/types/links";
 import { TextLevels } from "@/types/text";
 import { cn } from "@/utils/helpers";
+import { Heading, HeadingProps } from "./Heading";
 
 interface LinkTextProps {
-  href: LinkType | string;
-  textProps?: TextProps;
-  children?: React.ReactNode;
+  link: LinkType;
+  textProps?: TextProps | HeadingProps;
   className?: string;
 }
 
 const LinkText: FC<LinkTextProps> = ({
-  href,
+  link = { href: "/404", text: "MISSING LINK, PLEASE FIX :)" },
   textProps = { level: TextLevels.span },
   className,
   ...props
 }: LinkTextProps) => {
+  const isText: boolean = (textProps as TextProps).level !== undefined;
+
   return (
-    <Link
-      {...props}
-      className={cn("w-fit", className)}
-      href={typeof href === "object" ? href.href : href}
-    >
-      <Text {...textProps}>{props.children}</Text>
+    <Link {...props} className={cn("w-fit", className)} href={link.href}>
+      {isText ? (
+        <Text {...(textProps as TextProps)}>{link.text}</Text>
+      ) : (
+        <Heading {...(textProps as HeadingProps)}>{link.text}</Heading>
+      )}
     </Link>
   );
 };

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -21,10 +21,10 @@ import { AppData } from "@/data/records/apps";
 import AppCard from "../AppCard";
 import { Card } from "../Card";
 import { MixitLogo } from "@/assets/mixit";
-import { Links } from "@/types/links";
 import { LinkText } from "../base/LinkText";
 import { ContactData } from "@/data/objects/contact";
 import Link from "next/link";
+import { FooterLinks } from "@/data/objects/footer-links";
 
 interface AccordionItemProps extends Accordion.AccordionItemProps {
   className?: string;
@@ -119,11 +119,9 @@ const appsLinks = Object.keys(AppData).map((appKey) => {
 });
 
 const MobileFooter: React.FC = () => {
-  const aboutLinks = Object.values(Links.about).map((linkData) => (
-    <LinkText href={linkData.href} key={linkData.text}>
-      {linkData.text}
-    </LinkText>
-  ));
+  const aboutLinks = Object.values(FooterLinks.columnLinks.about.links).map(
+    (linkData) => <LinkText link={linkData} key={linkData.text} />
+  );
 
   return (
     <>
@@ -194,28 +192,26 @@ const MobileFooter: React.FC = () => {
               />
             </Link>
             <LinkText
-              href={Links.privacy.privacyPolicy}
+              link={FooterLinks.watermark.links.privacyPolicy}
               textProps={{ level: TextLevels.small }}
-            >
-              Privacy Policy
-            </LinkText>
+            />
           </div>
 
           <div className="flex flex-col sm:items-center">
-            <Text level={TextLevels.small}>Made with ❤️ by Miguel Jover.</Text>
             <Text level={TextLevels.small}>
-              Find the code{" "}
+              {FooterLinks.watermark.links.madeWithLove.before}
               <LinkText
-                href={Links.contact.repo}
+                link={{
+                  text: FooterLinks.watermark.links.madeWithLove.linkText,
+                  href: FooterLinks.watermark.links.madeWithLove.href,
+                }}
                 textProps={{
                   level: TextLevels.small,
                   underline: true,
                   underlineColor: "primary",
                 }}
-              >
-                here
-              </LinkText>
-              .
+              />
+              {FooterLinks.watermark.links.madeWithLove.after}
             </Text>
           </div>
         </div>
@@ -229,89 +225,122 @@ export const DesktopFooter: React.FC = () => {
     <div className="hidden h-full max-h-[330px] w-full flex-1 grid-cols-[2.5fr_1.5fr_1.25fr_1fr] lg:grid">
       <div className="flex max-h-fit flex-col justify-between">
         <div className="flex flex-col gap-32">
-          <Link href={"/"} aria-label="Mixit">
+          <Link href={"/"} aria-label="Mixit" className="w-fit">
             <MixitLogo
               width="180px"
               height="auto"
               fill="#fff"
-              className="block"
+              className="inline"
             />
           </Link>
-          <LinkText href={Links.privacy.privacyPolicy}>Privacy Policy</LinkText>
+          <LinkText link={FooterLinks.watermark.links.privacyPolicy} />
         </div>
 
         <div className="flex flex-col">
-          <Text level={TextLevels.small}>Made with ❤️ by Miguel Jover.</Text>
           <Text level={TextLevels.small}>
-            Find the code{" "}
+            {FooterLinks.watermark.links.madeWithLove.before}
             <LinkText
-              href={Links.contact.repo}
-              textProps={{ level: TextLevels.small, underline: true }}
-            >
-              here
-            </LinkText>
-            .
+              link={{
+                text: FooterLinks.watermark.links.madeWithLove.linkText,
+                href: FooterLinks.watermark.links.madeWithLove.href,
+              }}
+              textProps={{
+                level: TextLevels.small,
+                underline: true,
+                underlineColor: "primary",
+              }}
+            />
+            {FooterLinks.watermark.links.madeWithLove.after}
           </Text>
         </div>
       </div>
+      {Object.entries(FooterLinks.columnLinks).map(([key, value]) => (
+        <div className="flex h-full flex-col gap-32">
+          <LinkText
+            link={value.header.link}
+            textProps={{
+              level: HeadingLevels.h6,
+              className: "uppercase tracking-[3px] text-body font-bold",
+            }}
+            key={key}
+          />
 
-      <div className="flex h-full w-4/5 flex-col gap-32">
-        <Heading
-          level={HeadingLevels.h6}
-          className="uppercase tracking-[3px] text-body"
-        >
-          About
-        </Heading>
+          <div className="flex h-full flex-col gap-24">
+            {/* Render logos if the app column */}
+            {value.header === FooterLinks.columnLinks.apps.header
+              ? appsLinks
+              : Object.values(value.links).map((link) => (
+                  <LinkText
+                    link={link}
+                    className="block"
+                    key={link.text}
+                    textProps={
+                      link.text === "Contact us"
+                        ? {
+                            level: TextLevels.span,
+                            underline: true,
+                            underlineColor: "primary",
+                          }
+                        : { level: TextLevels.span }
+                    }
+                  />
+                ))}
+          </div>
+        </div>
+      ))}
+
+      {/* <div className="flex h-full flex-col gap-32">
+        <LinkText
+          link={{
+            text: "About",
+            href: FooterLinks.columnLinks.about.header.link.href,
+          }}
+          textProps={{
+            level: HeadingLevels.h6,
+            className: "uppercase tracking-[3px] text-body font-bold",
+          }}
+        />
 
         <div className="flex h-full flex-col gap-24">
-          {Object.values(Links.about).map((linkData) => (
-            <LinkText
-              href={linkData.href}
-              className="block"
-              key={linkData.text}
-            >
-              {linkData.text}
-            </LinkText>
+          {Object.values(FooterLinks.columnLinks.about.links).map((link) => (
+            <LinkText link={link} className="block" key={link.text} />
           ))}
         </div>
       </div>
 
       <div className="flex h-full flex-col gap-32">
-        <Heading
-          level={HeadingLevels.h6}
-          className="uppercase tracking-[3px] text-body"
-        >
-          Apps
-        </Heading>
+        <LinkText
+          link={{
+            text: "Apps",
+            href: FooterLinks.columnLinks.apps.header.link.href,
+          }}
+          textProps={{
+            level: HeadingLevels.h6,
+            className: "uppercase tracking-[3px] text-body font-bold",
+          }}
+        />
 
         <div className="flex h-full flex-col gap-24">{appsLinks}</div>
       </div>
 
       <div className="flex h-full flex-col gap-32">
-        <Heading
-          level={HeadingLevels.h6}
-          className="uppercase tracking-[3px] text-body"
-        >
-          Contact
-        </Heading>
+        <LinkText
+          link={{
+            text: "Contact",
+            href: FooterLinks.columnLinks.contact.header.link.href,
+          }}
+          textProps={{
+            level: HeadingLevels.h6,
+            className: "uppercase tracking-[3px] text-body font-bold",
+          }}
+        />
 
         <div className="flex h-full flex-col gap-24">
-          {Object.values(Links.contact).map((linkData) => (
-            <LinkText
-              href={linkData.href}
-              className="block"
-              textProps={
-                linkData.text === Links.contact.contactUs.text
-                  ? { underline: true, underlineColor: "primary" }
-                  : {}
-              }
-              key={linkData.text}
-            >
-              {linkData.text}
-            </LinkText>
+          {Object.values(FooterLinks.columnLinks.contact.links).map((link) => (
+            <LinkText link={link} className="block" key={link.text} />
           ))}
         </div>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -2,27 +2,20 @@
 import React, { forwardRef } from "react";
 import { cn } from "@/utils/helpers";
 import { Section } from "../base/Section";
-import { Pretitle } from "@/components/base/Pretitle";
 import { Heading } from "../base/Heading";
 import { HeadingLevels, TextLevels } from "@/types/text";
-import { BarChartIcon, ShufflerIcon, UserIcon } from "@/assets/svg";
-import { QueueIcon } from "@/assets/svg";
-import { Disc } from "../decorations/Disc";
+import { UserIcon } from "@/assets/svg";
 import * as Accordion from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { InfoIcon, AppsIcon } from "@/assets/svg";
 import ContactForm from "../ContactForm";
 import { Text } from "@/components/base/Text";
-import { ColorData } from "@/types/colors";
 import Separator from "../Separator";
-import { AppIcon, AppIconShapes, AppIconProps } from "../AppIcon";
+import { AppIcon, AppIconShapes } from "../AppIcon";
 import { Apps } from "@/types/apps";
 import { AppData } from "@/data/records/apps";
-import AppCard from "../AppCard";
-import { Card } from "../Card";
 import { MixitLogo } from "@/assets/mixit";
 import { LinkText } from "../base/LinkText";
-import { ContactData } from "@/data/objects/contact";
 import Link from "next/link";
 import { FooterLinks } from "@/data/objects/footer-links";
 
@@ -288,59 +281,6 @@ export const DesktopFooter: React.FC = () => {
           </div>
         </div>
       ))}
-
-      {/* <div className="flex h-full flex-col gap-32">
-        <LinkText
-          link={{
-            text: "About",
-            href: FooterLinks.columnLinks.about.header.link.href,
-          }}
-          textProps={{
-            level: HeadingLevels.h6,
-            className: "uppercase tracking-[3px] text-body font-bold",
-          }}
-        />
-
-        <div className="flex h-full flex-col gap-24">
-          {Object.values(FooterLinks.columnLinks.about.links).map((link) => (
-            <LinkText link={link} className="block" key={link.text} />
-          ))}
-        </div>
-      </div>
-
-      <div className="flex h-full flex-col gap-32">
-        <LinkText
-          link={{
-            text: "Apps",
-            href: FooterLinks.columnLinks.apps.header.link.href,
-          }}
-          textProps={{
-            level: HeadingLevels.h6,
-            className: "uppercase tracking-[3px] text-body font-bold",
-          }}
-        />
-
-        <div className="flex h-full flex-col gap-24">{appsLinks}</div>
-      </div>
-
-      <div className="flex h-full flex-col gap-32">
-        <LinkText
-          link={{
-            text: "Contact",
-            href: FooterLinks.columnLinks.contact.header.link.href,
-          }}
-          textProps={{
-            level: HeadingLevels.h6,
-            className: "uppercase tracking-[3px] text-body font-bold",
-          }}
-        />
-
-        <div className="flex h-full flex-col gap-24">
-          {Object.values(FooterLinks.columnLinks.contact.links).map((link) => (
-            <LinkText link={link} className="block" key={link.text} />
-          ))}
-        </div>
-      </div> */}
     </div>
   );
 };

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -14,10 +14,10 @@ import Separator from "../Separator";
 import { AppIcon, AppIconShapes } from "../AppIcon";
 import { Apps } from "@/types/apps";
 import { AppData } from "@/data/records/apps";
-import { MixitLogo } from "@/assets/mixit";
 import { LinkText } from "../base/LinkText";
 import Link from "next/link";
 import { FooterLinks } from "@/data/objects/footer-links";
+import MixitHomeLogo from "../MixitHomeLogo";
 
 interface AccordionItemProps extends Accordion.AccordionItemProps {
   className?: string;
@@ -144,7 +144,6 @@ const MobileFooter: React.FC = () => {
               </div>
             </AccordionTrigger>
             <AccordionContent>
-              {/* TODO: Add API endpoints */}
               <div className="grid grid-cols-2 gap-24">{appsLinks}</div>
             </AccordionContent>
           </AccordionItem>
@@ -176,14 +175,7 @@ const MobileFooter: React.FC = () => {
 
         <div className="mt-64 flex flex-col gap-16 sm:items-center">
           <div className="flex flex-col gap-8 sm:items-center">
-            <Link href={"/"} aria-label="Mixit" className="w-fit">
-              <MixitLogo
-                width="104px"
-                height="auto"
-                fill="#fff"
-                className="inline"
-              />
-            </Link>
+            <MixitHomeLogo width="108px" />
             <LinkText
               link={FooterLinks.watermark.links.privacyPolicy}
               textProps={{ level: TextLevels.small }}
@@ -218,14 +210,7 @@ export const DesktopFooter: React.FC = () => {
     <div className="hidden h-full max-h-[330px] w-full flex-1 grid-cols-[2.5fr_1.5fr_1.25fr_1fr] lg:grid">
       <div className="flex max-h-fit flex-col justify-between">
         <div className="flex flex-col gap-32">
-          <Link href={"/"} aria-label="Mixit" className="w-fit">
-            <MixitLogo
-              width="180px"
-              height="auto"
-              fill="#fff"
-              className="inline"
-            />
-          </Link>
+          <MixitHomeLogo width="180px" />
           <LinkText link={FooterLinks.watermark.links.privacyPolicy} />
         </div>
 

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -17,7 +17,7 @@ export function Hero({}) {
         padding
         container
         fitScreenHeight
-        className={`relative -top-[${NavbarHeight.mobile}] items-end md:grid-rows-none`}
+        className={`relative -top-[${NavbarHeight.mobile}] items-end md:grid-rows-none lg:top-0`}
       >
         {/* Content */}
         <div className="col-span-full row-start-2 lg:col-span-6 lg:row-start-1">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -6,6 +6,7 @@ import { Button } from "../Button";
 import Link from "next/link";
 import { Disc } from "../decorations/Disc";
 import { HeadingLevels, TextLevels } from "@/types/text";
+import { NavbarHeight } from "@/data/objects/navbar-data";
 
 export function Hero({}) {
   return (
@@ -16,7 +17,7 @@ export function Hero({}) {
         padding
         container
         fitScreenHeight
-        className="items-end md:grid-rows-none"
+        className={`relative -top-[${NavbarHeight.mobile}] items-end md:grid-rows-none`}
       >
         {/* Content */}
         <div className="col-span-full row-start-2 lg:col-span-6 lg:row-start-1">

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -43,19 +43,25 @@ const Navbar: React.FC = () => {
   });
 
   return (
-    <motion.nav
-      variants={{ visible: { y: 0 }, hidden: { y: "-100%" } }}
-      transition={{ duration: 0.35, ease: "easeInOut" }}
-      animate={hidden ? "hidden" : "visible"}
-      className={cn(
-        `h-${NavbarHeight.mobile}`,
-        "sticky top-0 z-40 mx-auto flex h-[60px] w-screen flex-row  bg-background px-32 py-16 lg:py-32"
-      )}
-    >
-      {mobileNavbar}
-      {/* Desktop Navbar is rendered when viewport >= lg breakpoint (1024px) */}
-      {desktopNavbar}
-    </motion.nav>
+    <nav className="sticky top-0 z-40 lg:absolute">
+      <motion.div
+        variants={{ visible: { y: 0 }, hidden: { y: "-100%" } }}
+        transition={{ duration: 0.35, ease: "easeInOut" }}
+        animate={hidden ? "hidden" : "visible"}
+        className=" mx-auto flex h-[60px] w-screen flex-row bg-background px-32 py-16 lg:hidden"
+      >
+        {mobileNavbar}
+      </motion.div>
+
+      <div
+        className={cn(
+          `h-${NavbarHeight.mobile}`,
+          "absolute top-0 z-40 mx-auto hidden h-[60px] w-screen flex-row  bg-background px-32 py-16 lg:flex lg:h-fit lg:py-32 "
+        )}
+      >
+        {desktopNavbar}
+      </div>
+    </nav>
   );
 };
 
@@ -158,7 +164,7 @@ export default Navbar;
 
 function DesktopNavbar(navbarLinkElements: React.ReactNode) {
   return (
-    <div className="u-container mx-auto hidden h-fit flex-1 flex-row items-center justify-between px-64 py-16 lg:flex">
+    <div className="u-container mx-auto  flex h-fit flex-1 flex-row items-center justify-between px-64 py-16">
       <MixitLogo
         fill="#fff"
         height="auto"

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -1,17 +1,16 @@
 "use client";
 import { MixitLogo } from "@/assets/mixit";
 import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
-
-import React from "react";
+import { motion, useMotionValueEvent, useScroll } from "framer-motion";
+import React, { useEffect, useState } from "react";
 import * as Accordion from "@radix-ui/react-accordion";
 import { cn } from "@/utils/helpers";
 import { LinkText } from "../base/LinkText";
 import { Links, Link as LinkType } from "@/types/links";
-import { NavbarLinks } from "@/data/objects/navbar-links";
+import { NavbarHeight, NavbarLinks } from "@/data/objects/navbar-data";
 import { HeadingLevels, TextLevels } from "@/types/text";
 import { Heading, HeadingProps } from "../base/Heading";
 import { Button } from "../Button";
-import { TextProps } from "../base/Text";
 
 const Navbar: React.FC = () => {
   const mobileLinkStyles: HeadingProps = {
@@ -26,12 +25,33 @@ const Navbar: React.FC = () => {
   const mobileNavbar = MobileNavbar(NavbarLinkElements(mobileLinkStyles));
   const desktopNavbar = DesktopNavbar(NavbarLinkElements(desktopLinkStyles));
 
+  const { scrollY } = useScroll();
+
+  const [hidden, setHidden] = useState(false);
+
+  useMotionValueEvent(scrollY, "change", (latest) => {
+    const previous = scrollY.getPrevious();
+    console.log("latest=" + latest + ", previous=" + previous);
+    if (latest > previous && latest > 150) {
+      setHidden(true);
+    } else {
+      setHidden(false);
+    }
+  });
   return (
-    <nav className="absolute z-40 mx-auto flex h-[60px] w-screen flex-row bg-background px-32 py-16 lg:py-32">
+    <motion.nav
+      variants={{ visible: { y: 0 }, hidden: { y: "-100%" } }}
+      transition={{ duration: 0.35, ease: "easeInOut" }}
+      animate={hidden ? "hidden" : "visible"}
+      className={cn(
+        `h-${NavbarHeight.mobile}`,
+        "sticky top-0 z-40 mx-auto flex h-[60px] w-screen flex-row overflow-x-hidden bg-background px-32 py-16 lg:py-32"
+      )}
+    >
       {mobileNavbar}
       {/* Desktop Navbar is rendered when viewport >= lg breakpoint (1024px) */}
       {desktopNavbar}
-    </nav>
+    </motion.nav>
   );
 };
 

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -2,66 +2,35 @@
 import { MixitLogo } from "@/assets/mixit";
 import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
 
-import React, { forwardRef } from "react";
+import React from "react";
 import * as Accordion from "@radix-ui/react-accordion";
 import { cn } from "@/utils/helpers";
 import { LinkText } from "../base/LinkText";
-import { Links } from "@/types/links";
+import { Links, Link as LinkType } from "@/types/links";
 import { NavbarLinks } from "@/data/objects/navbar-links";
 import { HeadingLevels, TextLevels } from "@/types/text";
-import Link from "next/link";
 import { Heading, HeadingProps } from "../base/Heading";
 import { Button } from "../Button";
+import { TextProps } from "../base/Text";
 
 const Navbar: React.FC = () => {
+  const mobileLinkStyles: HeadingProps = {
+    level: HeadingLevels.h2,
+    className: "uppercase",
+  };
+  const desktopLinkStyles: HeadingProps = {
+    level: HeadingLevels.h4,
+    className: "uppercase tracking-[3px]",
+  };
+
+  const mobileNavbar = MobileNavbar(NavbarLinkElements(mobileLinkStyles));
+  const desktopNavbar = DesktopNavbar(NavbarLinkElements(desktopLinkStyles));
+
   return (
-    <nav className="absolute z-40 flex h-[60px] w-screen flex-row bg-background px-32 py-16">
-      <Accordion.Root
-        type="single"
-        collapsible
-        className="flex flex-1 flex-row items-center justify-between"
-      >
-        <MixitLogo
-          fill="#fff"
-          height="auto"
-          width="auto"
-          className="w-fit max-w-[70px]"
-        />
-        <Accordion.Item value="item-1" className="group">
-          <AccordionTrigger />
-          <Accordion.Content className="absolute right-0 top-[60px] z-30 flex flex-col gap-64 overflow-hidden rounded-bl-3xl bg-background text-body data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown">
-            <div className="flex flex-col items-end gap-40 px-32 py-64">
-              <div className="flex flex-col items-end gap-20">
-                {NavbarLinks.map((link) => (
-                  <LinkText
-                    link={link}
-                    textProps={{
-                      className: "uppercase",
-                      level: HeadingLevels.h2,
-                    }}
-                    isHeading
-                  />
-                ))}
-              </div>
-              <Button
-                variant="outline"
-                size="cta"
-                href={Links.apps.root.href}
-                className="w-fit"
-              >
-                <Heading
-                  className="uppercase"
-                  textColor="primary"
-                  alignment="center"
-                  level={HeadingLevels.h2}
-                >
-                  Mix now
-                </Heading>
-              </Button>
-            </div>
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion.Root>
+    <nav className="absolute z-40 mx-auto flex h-[60px] w-screen flex-row bg-background px-32 py-16 lg:py-32">
+      {mobileNavbar}
+      {/* Desktop Navbar is rendered when viewport >= lg breakpoint (1024px) */}
+      {desktopNavbar}
     </nav>
   );
 };
@@ -101,4 +70,80 @@ const AccordionTrigger = React.forwardRef<
   );
 });
 
+const NavbarLinkElements = (
+  linkHeadingStyle: HeadingProps
+): React.ReactNode => {
+  return NavbarLinks.map((link) => {
+    return RenderNavbarLinkElement(link, linkHeadingStyle);
+  });
+};
+
+const RenderNavbarLinkElement = (
+  link: LinkType,
+  textStyle: HeadingProps
+): React.ReactNode => {
+  return link.href === Links.apps.root.href ? (
+    <Button
+      variant="outline"
+      size="default"
+      href={Links.apps.root.href}
+      className="w-fit"
+    >
+      <Heading
+        className={cn("uppercase", textStyle.className)}
+        textColor="primary"
+        alignment="center"
+        level={textStyle.level}
+      >
+        Mix now
+      </Heading>
+    </Button>
+  ) : (
+    <LinkText link={link} textProps={textStyle} isHeading />
+  );
+};
+
+function MobileNavbar(navbarLinkElements: React.ReactNode) {
+  return (
+    <Accordion.Root
+      type="single"
+      collapsible
+      className="flex flex-1 flex-row items-center justify-between lg:hidden"
+    >
+      <MixitLogo
+        fill="#fff"
+        height="auto"
+        width="auto"
+        className="w-fit max-w-[70px]"
+      />
+      <Accordion.Item value="item-1" className="group">
+        <AccordionTrigger />
+        <Accordion.Content className="absolute right-0 top-[60px] z-30 flex flex-col gap-64 overflow-hidden rounded-bl-3xl bg-background text-body data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown">
+          <div className="flex flex-col items-end gap-40 px-32 py-64">
+            <div className="flex flex-col items-end gap-20">
+              {navbarLinkElements}
+            </div>
+          </div>
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}
+
 export default Navbar;
+
+function DesktopNavbar(navbarLinkElements: React.ReactNode) {
+  return (
+    <div className="u-container mx-auto hidden h-fit flex-1 flex-row items-center justify-between px-64 py-16 lg:flex">
+      <MixitLogo
+        fill="#fff"
+        height="auto"
+        width="auto"
+        className="w-fit max-w-[125px]"
+      />
+      <div className="flex flex-row items-center gap-64 ">
+        {navbarLinkElements}
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { MixitLogo } from "@/assets/mixit";
+import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
+
+import React, { forwardRef } from "react";
+import * as Accordion from "@radix-ui/react-accordion";
+import { cn } from "@/utils/helpers";
+import { LinkText } from "../base/LinkText";
+import { Links } from "@/types/links";
+import { NavbarLinks } from "@/data/objects/navbar-links";
+import { HeadingLevels, TextLevels } from "@/types/text";
+import Link from "next/link";
+import { Heading, HeadingProps } from "../base/Heading";
+import { Button } from "../Button";
+
+const Navbar: React.FC = () => {
+  return (
+    <nav className="absolute z-40 flex h-[60px] w-screen flex-row bg-background px-32 py-16">
+      <Accordion.Root
+        type="single"
+        collapsible
+        className="flex flex-1 flex-row items-center justify-between"
+      >
+        <MixitLogo
+          fill="#fff"
+          height="auto"
+          width="auto"
+          className="w-fit max-w-[70px]"
+        />
+        <Accordion.Item value="item-1" className="group">
+          <AccordionTrigger />
+          <Accordion.Content className="absolute right-0 top-[60px] z-30 flex flex-col gap-64 overflow-hidden rounded-bl-3xl bg-background text-body data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown">
+            <div className="flex flex-col items-end gap-40 px-32 py-64">
+              <div className="flex flex-col items-end gap-20">
+                {NavbarLinks.map((link) => (
+                  <LinkText
+                    link={link}
+                    textProps={{
+                      className: "uppercase",
+                      level: HeadingLevels.h2,
+                    }}
+                    isHeading
+                  />
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="cta"
+                href={Links.apps.root.href}
+                className="w-fit"
+              >
+                <Heading
+                  className="uppercase"
+                  textColor="primary"
+                  alignment="center"
+                  level={HeadingLevels.h2}
+                >
+                  Mix now
+                </Heading>
+              </Button>
+            </div>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    </nav>
+  );
+};
+
+interface AccordionTriggerProps extends Accordion.AccordionTriggerProps {
+  className?: string;
+}
+
+const AccordionTrigger = React.forwardRef<
+  HTMLButtonElement,
+  AccordionTriggerProps
+>(({ className, ...props }: AccordionTriggerProps, forwardedRef) => {
+  return (
+    <Accordion.Header className="flex">
+      <Accordion.Trigger
+        className={className}
+        {...props}
+        ref={forwardedRef}
+        title="Expand Navigation Bar"
+      >
+        <div className="flex h-[40px] w-[40px] place-items-center justify-center">
+          <HamburgerMenuIcon
+            className={cn(
+              "h-3/5 w-3/5 text-body  group-data-[state=closed]:block group-data-[state=open]:hidden motion-safe:group-data-[state=closed]:animate-spinFadeIn motion-safe:group-data-[state=open]:animate-spinFadeOut"
+            )}
+            aria-hidden
+          />
+          <Cross1Icon
+            className={cn(
+              "h-3/5 w-3/5 text-body group-data-[state=open]:block group-data-[state=closed]:hidden motion-safe:group-data-[state=closed]:animate-spinFadeOut motion-safe:group-data-[state=open]:animate-spinFadeIn"
+            )}
+            aria-hidden
+          />
+        </div>
+      </Accordion.Trigger>
+    </Accordion.Header>
+  );
+});
+
+export default Navbar;

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -45,7 +45,7 @@ const Navbar: React.FC = () => {
       animate={hidden ? "hidden" : "visible"}
       className={cn(
         `h-${NavbarHeight.mobile}`,
-        "sticky top-0 z-40 mx-auto flex h-[60px] w-screen flex-row overflow-x-hidden bg-background px-32 py-16 lg:py-32"
+        "sticky top-0 z-40 mx-auto flex h-[60px] w-screen flex-row  bg-background px-32 py-16 lg:py-32"
       )}
     >
       {mobileNavbar}

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -2,7 +2,7 @@
 import { MixitLogo } from "@/assets/mixit";
 import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
 import { motion, useMotionValueEvent, useScroll } from "framer-motion";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import * as Accordion from "@radix-ui/react-accordion";
 import { cn } from "@/utils/helpers";
 import { LinkText } from "../base/LinkText";
@@ -11,6 +11,8 @@ import { NavbarHeight, NavbarLinks } from "@/data/objects/navbar-data";
 import { HeadingLevels, TextLevels } from "@/types/text";
 import { Heading, HeadingProps } from "../base/Heading";
 import { Button } from "../Button";
+
+let hideAccordion: boolean = false;
 
 const Navbar: React.FC = () => {
   const mobileLinkStyles: HeadingProps = {
@@ -31,13 +33,15 @@ const Navbar: React.FC = () => {
 
   useMotionValueEvent(scrollY, "change", (latest) => {
     const previous = scrollY.getPrevious();
-    console.log("latest=" + latest + ", previous=" + previous);
     if (latest > previous && latest > 150) {
       setHidden(true);
+      hideAccordion = true;
     } else {
       setHidden(false);
+      hideAccordion = false;
     }
   });
+
   return (
     <motion.nav
       variants={{ visible: { y: 0 }, hidden: { y: "-100%" } }}
@@ -136,7 +140,7 @@ function MobileNavbar(navbarLinkElements: React.ReactNode) {
         width="auto"
         className="w-fit max-w-[70px]"
       />
-      <Accordion.Item value="item-1" className="group">
+      <Accordion.Item value={hideAccordion ? "" : "item-1"} className="group">
         <AccordionTrigger />
         <Accordion.Content className="absolute right-0 top-[60px] z-30 flex flex-col gap-64 overflow-hidden rounded-bl-3xl bg-background text-body data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown">
           <div className="flex flex-col items-end gap-40 px-32 py-64">

--- a/src/data/objects/footer-links.ts
+++ b/src/data/objects/footer-links.ts
@@ -1,0 +1,70 @@
+import { AppsIcon, InfoIcon, UserIcon } from "@/assets/svg";
+import { Links } from "../../types/links";
+import { MixitIcon } from "@/assets/mixit";
+
+export const FooterLinks = {
+  columnLinks: {
+    about: {
+      header: {
+        link: Links.about.root,
+        icon: InfoIcon,
+      },
+      links: [
+        Links.about.whyUseMixit,
+        Links.about.mixitShuffle,
+        Links.about.spotifyShuffle,
+        Links.about.whatIsRandom,
+      ],
+    },
+    apps: {
+      header: {
+        link: { text: "Apps", href: Links.apps.root.href },
+        icon: AppsIcon,
+      },
+      links: [
+        Links.apps.Shuffler,
+        Links.apps.Blender,
+        Links.apps["Pick And Mix"],
+        Links.apps["Time Machine"],
+      ],
+    },
+    contact: {
+      header: {
+        link: Links.contact.root,
+        icon: UserIcon,
+      },
+      links: [
+        {
+          text: "Contact us",
+          href: Links.contact.root.href,
+        },
+        Links.contact.linkedIn,
+        Links.contact.github,
+        Links.contact.repo,
+      ],
+    },
+  },
+  watermark: {
+    header: {
+      icon: MixitIcon,
+    },
+    links: {
+      privacyPolicy: {
+        text: "Privacy Policy",
+        href: Links.privacy.root.href,
+      },
+      madeWithLove: {
+        before: "Made with ❤️ by ",
+        linkText: "Miguel Jover",
+        after: ".",
+        href: Links.contact.linkedIn.href,
+      },
+      repo: {
+        before: "Find the code ",
+        linkText: "here",
+        after: ".",
+        href: Links.privacy.root.href,
+      },
+    },
+  },
+};

--- a/src/data/objects/navbar-data.ts
+++ b/src/data/objects/navbar-data.ts
@@ -1,4 +1,10 @@
 import { Links } from "../../types/links";
+
+export const NavbarHeight = {
+  mobile: "60px",
+  desktop: "60px",
+};
+
 export const NavbarLinks = [
   Links.about.root,
   Links.contact.root,

--- a/src/data/objects/navbar-links.ts
+++ b/src/data/objects/navbar-links.ts
@@ -1,0 +1,2 @@
+import { Links } from "../../types/links";
+export const NavbarLinks = [Links.about.root, Links.contact.root];

--- a/src/data/objects/navbar-links.ts
+++ b/src/data/objects/navbar-links.ts
@@ -1,2 +1,6 @@
 import { Links } from "../../types/links";
-export const NavbarLinks = [Links.about.root, Links.contact.root];
+export const NavbarLinks = [
+  Links.about.root,
+  Links.contact.root,
+  Links.apps.root,
+];

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -9,6 +9,10 @@ export interface Link {
 
 export const Links = {
   about: {
+    root: {
+      text: "About",
+      href: "/about",
+    },
     whyUseMixit: {
       text: "Why use Mixit?",
       href: "/about/404",
@@ -27,6 +31,10 @@ export const Links = {
     } as Link,
   },
   apps: {
+    root: {
+      text: "Dashboard",
+      href: "/dashboard",
+    },
     [Apps.Shuffler]: {
       text: AppData.Shuffler.name,
       href: AppData.Shuffler.href,
@@ -45,8 +53,8 @@ export const Links = {
     } as Link,
   },
   contact: {
-    contactUs: {
-      text: "Contact us",
+    root: {
+      text: "Contact",
       href: "/contact",
     } as Link,
     linkedIn: {
@@ -63,7 +71,7 @@ export const Links = {
     } as Link,
   },
   privacy: {
-    privacyPolicy: {
+    root: {
       text: "Privacy Policy",
       href: "/privacy",
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,10 +74,20 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: 0 },
         },
+        rotate180: {
+          from: { transform: "rotate(0deg)" },
+          to: { transform: "rotate(180deg)" },
+        },
+        fadeOut: { from: { opacity: 1 }, to: { opacity: 0 } },
+        fadeIn: { from: { opacity: 0 }, to: { opacity: 1 } },
       },
       animation: {
         slideDown: "slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1)",
         slideUp: "slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1)",
+        spinFadeOut:
+          "rotate180 300ms cubic-bezier(.8,0,.2,1), fadeOut 300ms ease-in-out",
+        spinFadeIn:
+          "rotate180 300ms cubic-bezier(.8,0,.2,1), fadeIn 300ms ease-in-out",
         "disc-spin-cw": "spin 45s linear infinite",
         "disc-spin-ccw": "spin 45s linear infinite reverse",
       },
@@ -96,6 +106,12 @@ module.exports = {
       backgroundImage: {
         "accent-gradient":
           "linear-gradient(45deg, rgba(255, 232, 51, 1) 0%, rgba(51, 255, 130, 1) 100%)",
+      },
+      minWidth: {
+        screen: ["100vh /* fallback for Opera, IE and etc. */", "100svw"],
+      },
+      width: {
+        screen: ["100vh /* fallback for Opera, IE and etc. */", "100svw"],
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,12 +1069,24 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
   integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
   dependencies:
     "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.8.1":
   version "0.8.1"
@@ -3263,6 +3275,15 @@ fraction.js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
+
+framer-motion@^10.16.2:
+  version "10.16.2"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.16.2.tgz#b737f628f69a883824024124dab452273f73cbba"
+  integrity sha512-aY6L9YMvqMWtfOQptaUvvr8dp97jskXY5UYLQM0vOPxKeERrG/Z034EIQZ/52u7MeCT0HlCQy3/l0HdUZCB9Tw==
+  dependencies:
+    tslib "^2.4.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
 
 fs-extra@^11.0.0:
   version "11.1.1"


### PR DESCRIPTION
# Adding the navbar, which conditionally renders either a hamburger icon that expands into navbar links or a horizontal row of links depending on the viewport width. 

## Features
+ Different layout depending on viewport width
    + Mobile and tablet devices have a dropdown 
    + Larger screens (laptops and desktop PCs) have all links a row
+ Navbar scrolls in and out of view on mobile and tablet devices

<figcaption>

### Navbar animation preview
</figcaption>

<figure>

![mobile-nav-preview (1)](https://github.com/mianjoto/mixit/assets/78712025/0adfc283-a0f8-4c9c-a882-2ec7c91507a8)
</figure>

> Note: 200% speed


## Navbar on various devices
<details>
  <summary>

### This is what the "opened" navbar section looks like on mobile/tablet devices:
  </summary>

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
iPhone 12 Pro | 390x844 | ![localhost_3000_(iPhone 12 Pro) (3)](https://github.com/mianjoto/mixit/assets/78712025/ba0955dd-3288-4299-b152-92d024e0cf68)
iPad Air (Portrait) | 820x1180 | ![localhost_3000_(iPad Air) (7)](https://github.com/mianjoto/mixit/assets/78712025/ff144f80-0346-468a-8a03-ece16fab0059)

</details>
<details>
  <summary>

### This is what the "closed" navbar section looks like on all devices:
  </summary>

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
Desktop| 1440x1020 | ![localhost_3000_ (2)](https://github.com/mianjoto/mixit/assets/78712025/17e2a311-4552-4438-8f88-ef877832ced4)
iPhone 12 Pro | 390x844 | ![localhost_3000_(iPhone 12 Pro) (4)](https://github.com/mianjoto/mixit/assets/78712025/a8918871-38c8-4955-89a9-8359be2ad796)
iPad Air (Portrait) | 820x1180 | ![localhost_3000_(iPad Air) (5)](https://github.com/mianjoto/mixit/assets/78712025/f7b86b5c-b352-4625-a0af-09fa6a743ca1)
iPad Air (Landscape) | 1180x820 |  ![localhost_3000_(iPad Air) (6)](https://github.com/mianjoto/mixit/assets/78712025/1b588d8d-12e5-4fe5-aa4d-ad8cbe3643b9)

</details>

## Development notes

The dropdown was animated using the same root Accordion component from Radix UI. See #7 for more information.

The navbar scrolls out of view on mobile and tablet devices when you scroll down, and scrolls back into frame when you scroll up. This was animated by using the Motion component provided by [Framer Motion](https://www.framer.com/motion/). 

As mentioned in #7, the Navbar component does not truly use conditional rendering. As written in #7:

> Note: I understand that this is technically not conditional rendering, as both components are rendered and only one is made visible depending on the viewport width. For simplicity's sake, this solution is sufficient for now, but this may be something I revisit later if I determine this negatively impacts the user experience or loading times.