### PR TITLE
Fix select modal visual bug

### DIFF
--- a/src/app/(dashboard)/shuffler/page.tsx
+++ b/src/app/(dashboard)/shuffler/page.tsx
@@ -89,7 +89,7 @@ export default function Shuffler() {
     }
 
     // If playlist was chosen in dashboard (which would cause a null shuffleInput), store in ShuffleInput
-    if (!value && selectedPlaylistFromDashboard) {
+    if (!value && selectedPlaylistFromDashboard && !shuffleInput) {
       setShuffleInput({
         type: "all-playlists",
         playlist: selectedPlaylistFromDashboard,
@@ -104,6 +104,7 @@ export default function Shuffler() {
       setShuffleInput({ type: value, playlist: undefined });
     }
 
+    setSelectedPlaylistFromDashboard(NULL_SHUFFLE_INPUT);
     setSelectedPlaylistFromDashboard(null);
   }
 
@@ -114,22 +115,23 @@ export default function Shuffler() {
   // Determine what options should be visible depending on the form state
   const newFormState = {} as ShuffleFormState;
   useEffect(() => {
+    // Reset selected playlist if previously chosen from dashboard
+    newFormState.showSearchInput = false;
+    newFormState.showShuffleOutput = false;
+    newFormState.showMixButton = false;
+
     // Hide remaining form if unselecting the ShuffleInput
     if (shuffleInput.type === null) {
       if (selectedPlaylistFromDashboard) {
         setSelectedPlaylistFromDashboard(null);
         setSelectedPlaylist(null);
       }
-      // Reset selected playlist if previously chosen from dashboard
-      newFormState.showSearchInput = false;
-      newFormState.showShuffleOutput = false;
-      newFormState.showMixButton = false;
       setFormState(newFormState);
       return;
     }
 
     if (
-      selectedPlaylistFromDashboard !== null ||
+      selectedPlaylistFromDashboard ||
       shuffleInput?.type ===
         ("all-playlists" as
           | PlaylistShuffleType

--- a/src/app/(dashboard)/shuffler/page.tsx
+++ b/src/app/(dashboard)/shuffler/page.tsx
@@ -100,11 +100,10 @@ export default function Shuffler() {
     if (value === "liked-songs") {
       setShuffleInput({ type: "liked-songs", playlist: undefined });
       setSelectedPlaylist(null);
-    } else {
-      setShuffleInput({ type: value, playlist: undefined });
+      return;
     }
 
-    setSelectedPlaylistFromDashboard(NULL_SHUFFLE_INPUT);
+    setShuffleInput({ type: value, playlist: undefined });
     setSelectedPlaylistFromDashboard(null);
   }
 
@@ -149,8 +148,8 @@ export default function Shuffler() {
         newFormState.showMixButton = true;
       }
     } else if (
-      shuffleInput?.playlist !== undefined &&
-      shuffleOutput?.type !== undefined &&
+      shuffleInput?.playlist &&
+      shuffleOutput?.type &&
       shuffleOutput?.disabled !== true
     ) {
       newFormState.showMixButton = true;

--- a/src/components/app-form-card.tsx
+++ b/src/components/app-form-card.tsx
@@ -20,7 +20,7 @@ type AppFormCardRootProps = {
   description: string;
   image: string | React.JSX.Element;
   app: Apps;
-  isSelected?: boolean;
+  defaultSelected?: boolean;
   disabled?: { isDisabled: boolean; reasonForDisabling: string };
   className?: string;
   value: ShuffleInput | ShuffleOutput;
@@ -42,7 +42,7 @@ const AppFormCardRoot = ({
   description,
   image,
   app,
-  isSelected = false,
+  defaultSelected = false,
   disabled = undefined,
   className,
   value,
@@ -50,7 +50,7 @@ const AppFormCardRoot = ({
   const imageWithColor = getImageWithAccentColor(image, app);
   const ringColor = COLOR_VARIANTS[app];
   const ringClass =
-    !disabled || isSelected
+    !disabled || defaultSelected
       ? "ring-inset data-[state=off]:ring-0 data-[state=on]:ring-4"
       : "";
 
@@ -60,6 +60,8 @@ const AppFormCardRoot = ({
     disabled !== undefined
       ? ({ description: disabled.reasonForDisabling } as InfoTooltipContent)
       : null;
+
+  const dataState = defaultSelected ? "on" : "off";
 
   const card = (
     <DashboardCard
@@ -82,6 +84,7 @@ const AppFormCardRoot = ({
   return (
     <ToggleGroup.Item
       value={toggleValue}
+      data-state={dataState}
       disabled={toggleIsDisabled ?? toggleIsDisabled}
       className={cn(ringColor, ringClass, `rounded-[18px] `)}
       key={`${title}-${description}-dashboard-card-toggle-group-item`}
@@ -93,9 +96,9 @@ const AppFormCardRoot = ({
 
 type AppFormCardProps = {
   app: Apps;
-} & Pick<AppFormCardRootProps, "isSelected">;
+} & Pick<AppFormCardRootProps, "defaultSelected">;
 
-const LikedSongs = ({ app, isSelected }: AppFormCardProps) => {
+const LikedSongs = ({ app, defaultSelected }: AppFormCardProps) => {
   return (
     <AppFormCardRoot
       title="Liked Songs"
@@ -104,12 +107,12 @@ const LikedSongs = ({ app, isSelected }: AppFormCardProps) => {
       app={app}
       value={{ type: "liked-songs" } as ShuffleInput}
       key={"liked-songs-input-for-" + app}
-      isSelected={isSelected}
+      defaultSelected={defaultSelected}
     />
   );
 };
 
-const Playlists = ({ app, isSelected }: AppFormCardProps) => {
+const Playlists = ({ app, defaultSelected }: AppFormCardProps) => {
   return (
     <AppFormCardRoot
       title="Playlist"
@@ -118,7 +121,7 @@ const Playlists = ({ app, isSelected }: AppFormCardProps) => {
       app={app}
       value={{ type: "all-playlists" } as ShuffleInput}
       key={"playlists-input-for-" + app}
-      isSelected={isSelected}
+      defaultSelected={defaultSelected}
     />
   );
 };

--- a/src/components/app-form-card.tsx
+++ b/src/components/app-form-card.tsx
@@ -49,10 +49,9 @@ const AppFormCardRoot = ({
 }: AppFormCardRootProps) => {
   const imageWithColor = getImageWithAccentColor(image, app);
   const ringColor = COLOR_VARIANTS[app];
-  const ringClass =
-    !disabled || defaultSelected
-      ? "ring-inset data-[state=off]:ring-0 data-[state=on]:ring-4"
-      : "";
+  const ringClass = !disabled
+    ? "ring-inset data-[state=off]:ring-0 data-[state=on]:ring-4"
+    : "";
 
   const toggleIsDisabled = (value as ShuffleOutput)?.disabled;
   const toggleValue = value.type === null ? "" : (value.type as string);
@@ -60,8 +59,6 @@ const AppFormCardRoot = ({
     disabled !== undefined
       ? ({ description: disabled.reasonForDisabling } as InfoTooltipContent)
       : null;
-
-  const dataState = defaultSelected ? "on" : "off";
 
   const card = (
     <DashboardCard
@@ -84,7 +81,7 @@ const AppFormCardRoot = ({
   return (
     <ToggleGroup.Item
       value={toggleValue}
-      data-state={dataState}
+      defaultChecked={defaultSelected}
       disabled={toggleIsDisabled ?? toggleIsDisabled}
       className={cn(ringColor, ringClass, `rounded-[18px] `)}
       key={`${title}-${description}-dashboard-card-toggle-group-item`}
@@ -126,7 +123,7 @@ const Playlists = ({ app, defaultSelected }: AppFormCardProps) => {
   );
 };
 
-const CreateNewPlaylist = ({ app }: AppFormCardProps) => {
+const CreateNewPlaylist = ({ app, defaultSelected }: AppFormCardProps) => {
   return (
     <AppFormCardRoot
       title="Create new playlist"
@@ -134,6 +131,7 @@ const CreateNewPlaylist = ({ app }: AppFormCardProps) => {
       image={<PlaylistIcon className="h-[70%] w-[70%]" />}
       app={app}
       value={{ type: "new-playlist" } as ShuffleOutput}
+      defaultSelected={defaultSelected}
     />
   );
 };
@@ -143,8 +141,13 @@ type ChangeSongOrderProps = {
   shuffleInput: ShuffleInput;
 } & AppFormCardProps;
 
-const ChangeSongOrder = ({ app, user, shuffleInput }: ChangeSongOrderProps) => {
-  let { isDisabled, reasonForDisabling } = determineWhetherButtonIsDisabled(
+const ChangeSongOrder = ({
+  app,
+  user,
+  shuffleInput,
+  defaultSelected,
+}: ChangeSongOrderProps) => {
+  let { isDisabled, reasonForDisabling } = isChooseSongOrderOutputDisabled(
     shuffleInput,
     user
   );
@@ -169,6 +172,7 @@ const ChangeSongOrder = ({ app, user, shuffleInput }: ChangeSongOrderProps) => {
         value={radioValue}
         disabled={tooltipInfo}
         key={"change=song-order-output-for-" + app}
+        defaultSelected={defaultSelected}
       />
     </>
   );
@@ -198,7 +202,12 @@ function getImageWithAccentColor(
   );
 }
 
-function determineWhetherButtonIsDisabled(
+export const LIKED_SONGS_SONG_ORDER_DISABLED_REASON =
+  "You do not own the playlist, so you cannot change the song order of this playlist. You can create a copy of this playlist and try again.";
+export const USER_NOT_OWNER_SONG_ORDER_DISABLED_REASON =
+  "You cannot change the song order of your Liked Songs.";
+
+export function isChooseSongOrderOutputDisabled(
   shuffleInput: ShuffleInput,
   user: SpotifyApi.CurrentUsersProfileResponse | undefined
 ) {
@@ -208,8 +217,7 @@ function determineWhetherButtonIsDisabled(
   // Disable button if user is shuffling liked songs
   if (shuffleInput.type === "liked-songs") {
     isDisabled = true;
-    reasonForDisabling =
-      "You cannot change the song order of your Liked Songs.";
+    reasonForDisabling = LIKED_SONGS_SONG_ORDER_DISABLED_REASON;
   }
 
   // Disable button if the user does not have permission to change the song order
@@ -218,8 +226,7 @@ function determineWhetherButtonIsDisabled(
 
   if (!userOwnsPlaylist && shuffleInput?.playlist !== undefined) {
     isDisabled = true;
-    reasonForDisabling =
-      "You do not own the playlist, so you cannot change the song order of this playlist. You can create a copy of this playlist and try again.";
+    reasonForDisabling = USER_NOT_OWNER_SONG_ORDER_DISABLED_REASON;
   }
   return { isDisabled, reasonForDisabling };
 }

--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -41,8 +41,12 @@ export function AppFormPlaylistSearch({
   });
 
   let renderedResults;
-
-  if (populateWithPlaylist) {
+  console.log("shuffleInput", shuffleInput);
+  if (
+    populateWithPlaylist &&
+    (shuffleInput.type === "user-playlists" ||
+      shuffleInput.type === "all-playlists")
+  ) {
     renderedResults = renderPlaylist(populateWithPlaylist as Playlist, app);
   }
 

--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -41,7 +41,6 @@ export function AppFormPlaylistSearch({
   });
 
   let renderedResults;
-  console.log("shuffleInput", shuffleInput);
   if (
     populateWithPlaylist &&
     (shuffleInput.type === "user-playlists" ||

--- a/src/components/choose-shuffle-input-form.tsx
+++ b/src/components/choose-shuffle-input-form.tsx
@@ -47,12 +47,12 @@ export function ChooseShuffleInputForm({
             <AppFormCard.LikedSongs
               app={app}
               key={`liked-songs-input-for-${app}`}
-              isSelected={value === "liked-songs"}
+              defaultSelected={value === "liked-songs"}
             />
             <AppFormCard.Playlists
               app={app}
               key={`playlists-input-for-${app}`}
-              isSelected={value === "all-playlists"}
+              defaultSelected={value === "all-playlists"}
             />
           </>
         </ToggleGroup.Root>

--- a/src/components/choose-shuffle-output-form.tsx
+++ b/src/components/choose-shuffle-output-form.tsx
@@ -2,8 +2,13 @@ import { Apps } from "@/types/apps";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
 import { ShuffleInput, ShuffleOutputType } from "@/types/mixit";
 import { DashboardShelf } from "./dashboard-shelf";
-import { AppFormCard } from "./app-form-card";
+import {
+  AppFormCard,
+  USER_NOT_OWNER_SONG_ORDER_DISABLED_REASON,
+  isChooseSongOrderOutputDisabled,
+} from "./app-form-card";
 import { DashboardHeading } from "./dashboard";
+import { useEffect, useState } from "react";
 
 type ChooseShuffleOutputFormProps = {
   handleShuffleOutput: (value: ShuffleOutputType) => void;
@@ -18,24 +23,47 @@ export function ChooseShuffleOutputForm({
   user,
   shuffleInput,
 }: ChooseShuffleOutputFormProps) {
+  const [value, setValue] = useState<string | "">("");
+  const { isDisabled: songOrderIsDisabled } = isChooseSongOrderOutputDisabled(
+    shuffleInput!,
+    user
+  );
+
+  useEffect(() => {
+    if (songOrderIsDisabled || shuffleInput?.type === "liked-songs") {
+      setValue("new-playlist");
+      handleShuffleOutput("new-playlist");
+    }
+  }, [shuffleInput]);
+
   return (
-    <ToggleGroup.Root
-      orientation="horizontal"
-      asChild
-      type="single"
-      onValueChange={handleShuffleOutput}
-    >
-      <section className="flex flex-col gap-16">
-        <DashboardHeading text="How do you want to shuffle?" />
-        <DashboardShelf desktopBehavior={"grid"} className="py-2">
-          <AppFormCard.CreateNewPlaylist app={app} />
-          <AppFormCard.ChangeSongOrder
-            app={app}
-            user={user!}
-            shuffleInput={shuffleInput!}
-          />
-        </DashboardShelf>
-      </section>
-    </ToggleGroup.Root>
+    <section className="flex flex-col gap-16">
+      <DashboardHeading text="How do you want to shuffle?" />
+      <DashboardShelf desktopBehavior={"grid"} className="py-2">
+        <ToggleGroup.Root
+          orientation="horizontal"
+          type="single"
+          value={value}
+          onValueChange={(value: string) => {
+            handleShuffleOutput(value as ShuffleOutputType);
+            setValue(value);
+          }}
+          asChild
+        >
+          <>
+            <AppFormCard.CreateNewPlaylist
+              app={app}
+              defaultSelected={value === "new-playlist"}
+            />
+            <AppFormCard.ChangeSongOrder
+              app={app}
+              user={user!}
+              shuffleInput={shuffleInput!}
+              defaultSelected={value === "song-order"}
+            />
+          </>
+        </ToggleGroup.Root>
+      </DashboardShelf>
+    </section>
   );
 }


### PR DESCRIPTION
# Fixing a small edge case modal visual bug in the Shuffler

## Features
+ Fixed a bug where user was able to unselect the shuffle input and re-expose the previously selected playlist from the dashboard
+ Added default selection of output type when all other options are disabled

## Preview of features
<details>
  <summary>

### 🪲 Previous buggy behavior that is now fixed
  </summary>

![localhost_3000_shuffler (1)](https://github.com/mianjoto/mixit/assets/78712025/6dfc6e6a-59b1-4ea3-997f-e5d21fc5b4db)

Steps to replicate this visual bug:
1. Choose any playlist in the /dashboard route
2. Choose the Shuffler option when the modal pops up
3. Unselect the playlist you chose in the /dashboard route
4. Unselect the Playlist input option

This behavior is now fixed as deselecting the playlist will cause the Shuffler to not remember the selected playlist.

</details>


<details>
  <summary>

### 🛠️ New feature: Default options are chosen
  </summary>

![image](https://github.com/mianjoto/mixit/assets/78712025/59ab2324-a4c6-4099-86b4-c950d8bea5b1)
![localhost_3000_shuffler (2)](https://github.com/mianjoto/mixit/assets/78712025/2d80d48d-6deb-43a7-af62-b16abd8479ef)

Now the Shuffler will automatically select an option when there are no other options available.
</details>


