### PR TITLE
Adding contact form

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,3 +15,9 @@ NEXTAUTH_SECRET=
 # The URL of your NextAuth callbacks
 # Usually http://localhost:3000 for development
 NEXTAUTH_URL=http://localhost:3000 
+
+# The API key for Resend
+RESEND_API_KEY=
+
+# The email endpoint for the Resend Contact form
+RESEND_EMAIL_ENDPOINT=example@email.com

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const ContactFormSchema = z.object({
+  name: z.string().nonempty("Name is required."),
+  email: z.string().nonempty("Email is required.").email("Invalid email."),
+  message: z
+    .string()
+    .nonempty("Message is required")
+    .min(6, { message: "Message must be at least 6 characters." }),
+});
+
+export type ContactFormInputs = z.infer<typeof ContactFormSchema>;

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ const config = {
     });
     return config;
   },
+  experimental: {
+    serverActions: true,
+  },
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.23.2",
+    "@hookform/resolvers": "^3.3.2",
     "@mui/base": "^5.0.0-beta.13",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.3",
@@ -42,7 +43,9 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.47.0",
     "react-loading-skeleton": "^3.3.1",
+    "resend": "^1.1.0",
     "spotify-web-api-node": "^5.0.2",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/app/_actions.ts
+++ b/src/app/_actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { Resend } from "resend";
+import { ContactFormInputs, ContactFormSchema } from "@/../lib/schema";
+import ContactFormEmail from "@/emails/contact-form-email";
+
+const resend = new Resend(process.env.RESEND_API_KEY as string);
+const contactEmailEndpoint = process.env.RESEND_EMAIL_ENDPOINT as string;
+
+export async function sendEmail(data: ContactFormInputs) {
+  const result = ContactFormSchema.safeParse(data);
+
+  if (result.success) {
+    const { name, email, message } = result.data;
+    try {
+      const data = await resend.emails.send({
+        from: "Contact form <contact@mixit.fm>",
+        to: ["Miguel Jover <mianjoto@gmail.com>"],
+        subject: "Contact form submission",
+        text: `Name: ${name}\nEmail: ${email}\nMessage: ${message}`,
+        react: ContactFormEmail({ name, email, message }),
+      });
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error };
+    }
+  }
+
+  if (result.error) {
+    return { success: false, error: result.error.format };
+  }
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,13 +1,39 @@
 import ContactForm from "@/components/contact-form";
 import { LandingNavbar } from "@/components/landing-navbar";
+import { Section } from "@/components/ui/section";
+import { NavbarHeight } from "@/data/objects/navbar-data";
+import { Heading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import { HeadingLevels } from "@/types/text";
 
 export default function ContactPage() {
   return (
     <>
       <LandingNavbar />
-      {/* Fix this spacing issue later */}
-      <div className="h-160"></div>
-      <ContactForm />
+      <Section
+        level="main"
+        padding
+        fitScreenHeight
+        compensateForFooter
+        className={`relative -top-[${NavbarHeight.mobile}] flex w-full flex-col md:w-3/5 md:items-center md:justify-center lg:top-0`}
+      >
+        <article className="mt-32 flex max-w-screen-md flex-col gap-20 md:mt-0">
+          <div>
+            <Heading
+              level={HeadingLevels.h3}
+              alignment="left"
+              className="mb-[10px] w-full"
+            >
+              Contact us
+            </Heading>
+            <Text textColor="gray" className="w-full">
+              Have feedback? Want a new feature added to Mixit? Send a message
+              below, and I'll get back to you as soon as possible.
+            </Text>
+          </div>
+          <ContactForm className="w-full" />
+        </article>
+      </Section>
     </>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,40 +1,12 @@
-import ContactForm from "@/components/contact-form";
+import { ContactUsSection } from "@/components/contact-us-section";
 import { LandingNavbar } from "@/components/landing-navbar";
-import { Section } from "@/components/ui/section";
-import { NavbarHeight } from "@/data/objects/navbar-data";
-import { Heading } from "@/components/ui/heading";
-import { Text } from "@/components/ui/text";
-import { HeadingLevels } from "@/types/text";
 import Footer from "@/components/footer";
 
 export default function ContactPage() {
   return (
     <>
       <LandingNavbar />
-      <Section
-        level="main"
-        padding
-        fitScreenHeight
-        compensateForFooter
-        className={`relative -top-[${NavbarHeight.mobile}] flex w-full flex-col md:w-3/5 md:items-center md:justify-center lg:top-0`}
-      >
-        <article className="mt-32 flex max-w-screen-md flex-col gap-20 md:mt-0">
-          <div>
-            <Heading
-              level={HeadingLevels.h3}
-              alignment="left"
-              className="mb-[10px] w-full"
-            >
-              Contact us
-            </Heading>
-            <Text textColor="gray" className="w-full">
-              Have feedback? Want a new feature added to Mixit? Send a message
-              below, and I'll get back to you as soon as possible.
-            </Text>
-          </div>
-          <ContactForm className="w-full" />
-        </article>
-      </Section>
+      <ContactUsSection />
       <Footer />
     </>
   );

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,13 @@
+import ContactForm from "@/components/contact-form";
+import { LandingNavbar } from "@/components/landing-navbar";
+
+export default function ContactPage() {
+  return (
+    <>
+      <LandingNavbar />
+      {/* Fix this spacing issue later */}
+      <div className="h-160"></div>
+      <ContactForm />
+    </>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,7 @@ import { NavbarHeight } from "@/data/objects/navbar-data";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
 import { HeadingLevels } from "@/types/text";
+import Footer from "@/components/footer";
 
 export default function ContactPage() {
   return (
@@ -34,6 +35,7 @@ export default function ContactPage() {
           <ContactForm className="w-full" />
         </article>
       </Section>
+      <Footer />
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function Index() {
       <Features />
       <WhyUseMixit />
       <CallToAction />
-      <Footer />
+      <Footer showContactFormOnMobile />
       <div className="relative w-full">
         <Separator color="gradient" className="absolute bottom-0 w-screen" />
       </div>

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,92 +1,143 @@
+"use client";
+
 import React from "react";
 import * as Form from "@radix-ui/react-form";
 import { Button } from "./ui/button";
 import { cn } from "../../lib/utils";
 import { TextareaAutosize } from "@mui/base/TextareaAutosize";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { ContactFormInputs, ContactFormSchema } from "@/../lib/schema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { sendEmail } from "@/app/_actions";
+import { useToast } from "@/hooks/useToast";
 
 interface ContactFormProps
   extends Form.FormProps,
     React.HTMLAttributes<HTMLFormElement> {}
 
-const ContactForm = ({ className, ...props }: ContactFormProps) => (
-  <Form.Root className={cn("flex flex-col gap-16", className)} {...props}>
-    <Form.Field name="name">
-      <div className="mb-4">
-        <Form.Label className="text-base font-bold text-body">Name</Form.Label>
-      </div>
-      <Form.Control
-        className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
-        asChild
-      >
-        <input
-          type="name"
-          className="placeholder:text-gray"
-          placeholder="Enter your name"
-          required
-        />
-      </Form.Control>
-      <Form.Message match="valueMissing" className="text-danger">
-        Please enter your name
-      </Form.Message>
-      <Form.Message match="typeMismatch" className="text-danger">
-        Please provide a valid name
-      </Form.Message>
-    </Form.Field>
+const ContactForm = ({ className, ...props }: ContactFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ContactFormInputs>({
+    resolver: zodResolver(ContactFormSchema),
+  });
 
-    <Form.Field name="email">
-      <div className="mb-4">
-        <Form.Label className="text-base font-bold text-body">Email</Form.Label>
-      </div>
-      <Form.Control
-        className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
-        asChild
-      >
-        <input
-          type="email"
-          className="placeholder:text-gray"
-          placeholder="Enter your email address"
-          required
-        />
-      </Form.Control>
-      <Form.Message match="valueMissing" className="text-danger">
-        Please enter your email
-      </Form.Message>
-      <Form.Message match="typeMismatch" className="text-danger">
-        Please provide a valid email
-      </Form.Message>
-    </Form.Field>
+  const { toast } = useToast();
 
-    <Form.Field name="question">
-      <div className="mb-4">
-        <Form.Label className="text-base font-bold text-body">
-          Message
-        </Form.Label>
-      </div>
-      <Form.Control
-        className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
-        asChild
-      >
-        <TextareaAutosize
-          className="placeholder:text-gray"
-          placeholder="Enter your message (500 characters)"
-          maxLength={500}
-          minRows={5}
-          required
-          style={{ resize: "none" }}
-        />
-      </Form.Control>
+  const processForm: SubmitHandler<ContactFormInputs> = async (data) => {
+    const result = await sendEmail(data);
 
-      <Form.Message match="valueMissing" className="text-danger">
-        Please enter your message
-      </Form.Message>
-    </Form.Field>
+    if (result?.success) {
+      toast({ title: "✅ Success!", description: "Your email was sent." });
+      reset();
+      return;
+    }
 
-    <Form.Submit asChild>
-      <Button className="w-full" type="submit">
-        Send message
-      </Button>
-    </Form.Submit>
-  </Form.Root>
-);
+    toast({
+      title: "😑 Something went wrong...",
+      description: "Please try again in a moment.",
+      variant: "destructive",
+    });
+  };
+
+  return (
+    <Form.Root
+      className={cn("flex flex-col gap-16", className)}
+      onSubmit={handleSubmit(processForm)}
+      {...props}
+    >
+      <Form.Field name="name">
+        <div className="mb-4">
+          <Form.Label className="text-base font-bold text-body">
+            Name
+          </Form.Label>
+        </div>
+        <Form.Control
+          className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
+          asChild
+        >
+          <input
+            type="name"
+            className="placeholder:text-gray"
+            placeholder="Enter your name"
+            required
+            {...register("name")}
+          />
+        </Form.Control>
+        <Form.Message match="valueMissing" className="text-danger">
+          Please enter your name
+        </Form.Message>
+        <Form.Message match="typeMismatch" className="text-danger">
+          Please provide a valid name
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="email">
+        <div className="mb-4">
+          <Form.Label className="text-base font-bold text-body">
+            Email
+          </Form.Label>
+        </div>
+        <Form.Control
+          className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
+          asChild
+        >
+          <input
+            type="email"
+            className="placeholder:text-gray"
+            placeholder="Enter your email address"
+            required
+            {...register("email")}
+          />
+        </Form.Control>
+        <Form.Message match="valueMissing" className="text-danger">
+          Please enter your email
+        </Form.Message>
+        <Form.Message match="typeMismatch" className="text-danger">
+          Please provide a valid email
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="question">
+        <div className="mb-4">
+          <Form.Label className="text-base font-bold text-body">
+            Message
+          </Form.Label>
+        </div>
+        <Form.Control
+          className="w-full rounded-[8px] bg-secondary px-12 py-8 text-body"
+          asChild
+        >
+          <TextareaAutosize
+            className="placeholder:text-gray"
+            placeholder="Enter your message (500 characters)"
+            maxLength={500}
+            minLength={6}
+            minRows={5}
+            required
+            style={{ resize: "none" }}
+            {...register("message")}
+          />
+        </Form.Control>
+
+        <Form.Message match="valueMissing" className="text-danger">
+          Please enter your message
+        </Form.Message>
+        <Form.Message match="tooShort" className="text-danger">
+          Please enter at least 6 characters
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Submit asChild>
+        <Button className="w-full" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Sending message..." : "Send message"}
+        </Button>
+      </Form.Submit>
+    </Form.Root>
+  );
+};
 
 export default ContactForm;

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -47,6 +47,7 @@ const ContactForm = ({ className, ...props }: ContactFormProps) => {
     <Form.Root
       className={cn("flex flex-col gap-16", className)}
       onSubmit={handleSubmit(processForm)}
+      autoComplete="off"
       {...props}
     >
       <Form.Field name="name">
@@ -64,6 +65,7 @@ const ContactForm = ({ className, ...props }: ContactFormProps) => {
             className="placeholder:text-gray"
             placeholder="Enter your name"
             required
+            autoComplete="off"
             {...register("name")}
           />
         </Form.Control>
@@ -90,6 +92,7 @@ const ContactForm = ({ className, ...props }: ContactFormProps) => {
             className="placeholder:text-gray"
             placeholder="Enter your email address"
             required
+            autoComplete="off"
             {...register("email")}
           />
         </Form.Control>

--- a/src/components/contact-us-section.tsx
+++ b/src/components/contact-us-section.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Section } from "./ui/section";
+import { NavbarHeight } from "@/data/objects/navbar-data";
+import { HeadingLevels } from "@/types/text";
+import ContactForm from "./contact-form";
+import { Heading } from "./ui/heading";
+import { Text } from "./ui/text";
+
+export function ContactUsSection({}) {
+  return (
+    <Section
+      level="main"
+      padding
+      fitScreenHeight
+      compensateForFooter
+      className={`relative -top-[${NavbarHeight.mobile}] flex w-full flex-col md:w-3/5 md:items-center md:justify-center lg:top-0`}
+    >
+      <article className="mt-32 flex max-w-screen-md flex-col gap-20 md:mt-0">
+        <div>
+          <Heading
+            level={HeadingLevels.h3}
+            alignment="left"
+            className="mb-[10px] w-full"
+          >
+            Contact us
+          </Heading>
+          <Text textColor="gray" className="w-full">
+            Have feedback? Want a new feature added to Mixit? Send a message
+            below, and I'll get back to you as soon as possible.
+          </Text>
+        </div>
+        <ContactForm className="w-full" />
+      </article>
+    </Section>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -40,17 +40,59 @@ const appsLinks = Object.keys(AppData).map((appKey) => {
   );
 });
 
-const MobileFooter: React.FC = () => {
+type MobileFooterProps = { showContactForm: boolean };
+
+const MobileFooter = ({ showContactForm = false }: MobileFooterProps) => {
   const aboutLinks = Object.values(FooterLinks.columnLinks.about.links).map(
     (linkData) => <LinkText link={linkData} key={linkData.text} />
   );
+  const defaultOpenedColumns = ["item-1", "item-2"];
+
+  let contactContent = undefined;
+  if (showContactForm) {
+    contactContent = (
+      <AccordionContent contentGapClass="gap-[20px]" className="mt-20">
+        <div>
+          <Heading level={HeadingLevels.h3} className="mb-[10px]">
+            Want to get in touch?
+          </Heading>
+          <Text textColor="gray">
+            Send me a message, and I'll get back to you as soon as possible.
+          </Text>
+        </div>
+        <ContactForm />
+      </AccordionContent>
+    );
+  } else {
+    contactContent = (
+      <AccordionContent>
+        {Object.values(FooterLinks.columnLinks.contact.links).map((link) => (
+          <LinkText
+            link={link}
+            className="block"
+            key={link.text}
+            textProps={
+              link.text === "Contact us"
+                ? {
+                    level: TextLevels.span,
+                    underline: true,
+                    underlineColor: "primary",
+                  }
+                : { level: TextLevels.span }
+            }
+          />
+        ))}
+      </AccordionContent>
+    );
+    defaultOpenedColumns.push("item-3");
+  }
 
   return (
     <>
       <div className="lg:hidden">
         <Accordion.Root
           type="multiple"
-          defaultValue={["item-1", "item-2"]}
+          defaultValue={defaultOpenedColumns}
           className="flex flex-col gap-24"
         >
           <AccordionItem value="item-1">
@@ -86,18 +128,7 @@ const MobileFooter: React.FC = () => {
                 Contact
               </div>
             </AccordionTrigger>
-            <AccordionContent contentGapClass="gap-[20px]" className="mt-20">
-              <div>
-                <Heading level={HeadingLevels.h3} className="mb-[10px]">
-                  Want to get in touch?
-                </Heading>
-                <Text textColor="gray">
-                  Send me a message, and I'll get back to you as soon as
-                  possible.
-                </Text>
-              </div>
-              <ContactForm />
-            </AccordionContent>
+            {contactContent}
           </AccordionItem>
           <Separator />
         </Accordion.Root>
@@ -198,7 +229,11 @@ export const DesktopFooter: React.FC = () => {
   );
 };
 
-const Footer: React.FC = () => {
+type FooterProps = {
+  showContactFormOnMobile?: boolean;
+};
+
+const Footer = ({ showContactFormOnMobile = false }: FooterProps) => {
   return (
     <>
       <Section
@@ -207,7 +242,7 @@ const Footer: React.FC = () => {
         padding
         className="flex flex-col justify-end lg:min-h-[80svh]"
       >
-        <MobileFooter />
+        <MobileFooter showContactForm={showContactFormOnMobile} />
         <DesktopFooter />
       </Section>
     </>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -16,6 +16,7 @@ export function Hero({}) {
         padding
         container
         fitScreenHeight
+        compensateForFooter
         className={`relative -top-[${NavbarHeight.mobile}] items-end md:grid-rows-none lg:top-0`}
       >
         {/* Content */}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -118,12 +118,10 @@ const Navbar: React.FC<NavbarProps> = ({
     mobileIsHiddenAtClass
   );
 
-  const desktopClasses =
-    `h-${NavbarHeight.mobile}` +
-    cn(
-      "absolute top-0 z-40 mx-auto hidden h-[60px] w-screen flex-row  bg-background px-32 py-16 md:h-fit md:py-32",
-      desktopIsVisibleAtClass
-    );
+  const desktopClasses = cn(
+    "block z-40 mx-auto hidden md:h-[60px] w-screen flex-row  bg-background px-32 py-16 md:h-fit md:py-32",
+    desktopIsVisibleAtClass
+  );
 
   return (
     <nav

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -39,6 +39,10 @@ const sectionVariants = cva("", {
       true: "sticky top-0",
       false: "",
     },
+    compensateForFooter: {
+      true: "relative -top-[60px] md:static md:top-0",
+      false: "",
+    },
   },
   defaultVariants: {
     level: "section",
@@ -47,6 +51,7 @@ const sectionVariants = cva("", {
     padding: false,
     fitScreenHeight: false,
     sticky: false,
+    compensateForFooter: false,
   },
 });
 
@@ -70,6 +75,7 @@ interface SectionProps
   grid?: boolean;
   padding?: boolean;
   sticky?: boolean;
+  compensateForFooter?: boolean;
 }
 
 const Section: FC<SectionProps> = ({
@@ -79,6 +85,7 @@ const Section: FC<SectionProps> = ({
   padding = false,
   fitScreenHeight = false,
   sticky = false,
+  compensateForFooter = false,
   className,
   ...props
 }) => {
@@ -94,6 +101,7 @@ const Section: FC<SectionProps> = ({
           padding,
           sticky,
           fitScreenHeight,
+          compensateForFooter,
           className,
         })
       )}

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -6,7 +6,7 @@ import React, { FC } from "react";
 const textVariants = cva("text-base leading-[24px]", {
   variants: {
     level: {
-      p: "max-w-prose text-base",
+      p: "text-base",
       small: "text-sm",
       strong: "font-bold",
       figcaption: "max-w-prose",

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -30,8 +30,7 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: "border bg-tertiary text-body",
-        destructive:
-          "destructive border-destructive bg-destructive text-destructive-foreground group",
+        destructive: "danger group border-danger bg-danger text-body",
       },
     },
     defaultVariants: {

--- a/src/emails/contact-form-email.tsx
+++ b/src/emails/contact-form-email.tsx
@@ -1,0 +1,17 @@
+type ContactFormEmailProps = {
+  name: string;
+  email: string;
+  message: string;
+};
+
+const ContactFormEmail = ({ name, email, message }: ContactFormEmailProps) => (
+  <div>
+    <h1>Contact form submission</h1>
+    <p>
+      From <strong>{name}</strong> at {email}
+    </p>
+    <h2>Message:</h2>
+    <p>{message}</p>
+  </div>
+);
+export default ContactFormEmail;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,6 +1282,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
 
+"@hookform/resolvers@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.2.tgz#5c40f06fe8137390b071d961c66d27ee8f76f3bc"
+  integrity sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==
+
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.12"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.12.tgz#549afec9bfce5232ac6325db12765f407e70e3a0"
@@ -1694,6 +1699,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@one-ini/wasm@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@one-ini/wasm/-/wasm-0.1.1.tgz#6013659736c9dbfccc96e8a9c2b3de317df39323"
+  integrity sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==
 
 "@panva/hkdf@^1.0.2":
   version "1.1.1"
@@ -2183,6 +2193,16 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@react-email/render@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@react-email/render/-/render-0.0.7.tgz#92a14e03a59160c39bceeff50517c7058721ab6f"
+  integrity sha512-hMMhxk6TpOcDC5qnKzXPVJoVGEwfm+U5bGOPH+MyTTlx0F02RLQygcATBKsbP7aI/mvkmBAZoFbgPIHop7ovug==
+  dependencies:
+    html-to-text "9.0.3"
+    pretty "2.0.0"
+    react "18.2.0"
+    react-dom "18.2.0"
+
 "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
   resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz"
@@ -2191,6 +2211,14 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
+
+"@selderee/plugin-htmlparser2@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.10.0.tgz#8a304d18df907e086f3cfc71ea0ced52d6524430"
+  integrity sha512-gW69MEamZ4wk1OsOq1nG1jcyhXIQcnrsX5JwixVw/9xaiav8TCyjESAruu1Rz9yyInhgBXxkNwMeygKnN2uxNA==
+  dependencies:
+    domhandler "^5.0.3"
+    selderee "^0.10.0"
 
 "@shrutibalasa/tailwind-grid-auto-fit@^1.1.0":
   version "1.1.0"
@@ -2826,6 +2854,11 @@
   dependencies:
     "@swc/core" "^1.3.61"
 
+abbrev@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -3155,6 +3188,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
@@ -3366,6 +3406,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
@@ -3385,6 +3430,23 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+condense-newlines@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
+  integrity sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-whitespace "^0.3.0"
+    kind-of "^3.0.2"
+
+config-chain@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
@@ -3655,6 +3717,16 @@ dot-case@^3.0.4:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+editorconfig@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-1.0.4.tgz#040c9a8e9a6c5288388b87c2db07028aa89f53a3"
+  integrity sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==
+  dependencies:
+    "@one-ini/wasm" "0.1.1"
+    commander "^10.0.0"
+    minimatch "9.0.1"
+    semver "^7.5.3"
 
 electron-to-chromium@^1.4.431:
   version "1.4.465"
@@ -3971,6 +4043,13 @@ expect@^29.6.1:
     jest-message-util "^29.6.1"
     jest-util "^29.6.1"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
+  dependencies:
+    is-extendable "^0.1.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4236,6 +4315,17 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
@@ -4346,6 +4436,27 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-to-text@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-9.0.3.tgz#331368f32fcb270c59dbd3a7fdb32813d2a490bc"
+  integrity sha512-hxDF1kVCF2uw4VUJ3vr2doc91pXf2D5ngKcNviSitNkhP9OMOaJkDrFIFL6RMvko7NisWTEiqGpQ9LAxcVok1w==
+  dependencies:
+    "@selderee/plugin-htmlparser2" "^0.10.0"
+    deepmerge "^4.2.2"
+    dom-serializer "^2.0.0"
+    htmlparser2 "^8.0.1"
+    selderee "^0.10.0"
+
+htmlparser2@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
@@ -4394,6 +4505,11 @@ inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"
@@ -4455,6 +4571,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz"
@@ -4480,6 +4601,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
   dependencies:
     has-tostringtag "^1.0.0"
+
+is-extendable@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -4600,6 +4726,11 @@ is-what@^4.1.8:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.15.tgz#de43a81090417a425942d67b1ae86e7fae2eee0e"
   integrity sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==
+
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
+  integrity sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -5108,6 +5239,16 @@ jose@^4.11.4, jose@^4.14.4:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.6.tgz#94dca1d04a0ad8c6bff0998cdb51220d473cc3af"
   integrity sha512-EqJPEUlZD0/CSUMubKtMaYUOtWe91tZXTWMJZoKSbLk+KtdhNdcvppH8lA9XwVu2V4Ailvsj0GBZJ2ZwDjfesQ==
 
+js-beautify@^1.6.12:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.9.tgz#a5db728bc5a0d84d3b1a597c376b29bd4d39c8e5"
+  integrity sha512-coM7xq1syLcMyuVGyToxcj2AlzhkDjmfklL8r0JgJ7A76wyGMpJ1oA35mr4APdYNO/o/4YY8H54NQIJzhMbhBg==
+  dependencies:
+    config-chain "^1.1.13"
+    editorconfig "^1.0.3"
+    glob "^8.1.0"
+    nopt "^6.0.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -5189,10 +5330,22 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==
+  dependencies:
+    is-buffer "^1.1.5"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+leac@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/leac/-/leac-0.6.0.tgz#dcf136e382e666bd2475f44a1096061b70dc0912"
+  integrity sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -5358,12 +5511,26 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
+  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 ms@2.1.2:
   version "2.1.2"
@@ -5445,6 +5612,13 @@ node-releases@^2.0.12, node-releases@^2.0.13:
   version "2.0.13"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz"
   integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+
+nopt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-6.0.0.tgz#245801d8ebf409c6df22ab9d95b65e1309cdb16d"
+  integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
+  dependencies:
+    abbrev "^1.0.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -5644,6 +5818,14 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parseley@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/parseley/-/parseley-0.11.0.tgz#1ff817c829a02fcc214c9cc0d96b126d772ee814"
+  integrity sha512-VfcwXlBWgTF+unPcr7yu3HSSA6QUdDaDnrHcytVfj5Z8azAyKBDrYnSIfeSxlrEayndNcLmrXzg+Vxbo6DWRXQ==
+  dependencies:
+    leac "^0.6.0"
+    peberminta "^0.8.0"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
@@ -5668,6 +5850,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+peberminta@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/peberminta/-/peberminta-0.8.0.tgz#acf7b105f3d13c8ac28cad81f2f5fe4698507590"
+  integrity sha512-YYEs+eauIjDH5nUEGi18EohWE0nV2QbGTqmxQcqgZ/0g+laPCQmuIqq7EBLVi9uim9zMgfJv0QBZEnQ3uHw/Tw==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -5857,6 +6044,15 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
 
+pretty@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
+  integrity sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==
+  dependencies:
+    condense-newlines "^0.2.1"
+    extend-shallow "^2.0.1"
+    js-beautify "^1.6.12"
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz"
@@ -5873,6 +6069,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 punycode@^2.1.0:
   version "2.3.0"
@@ -5903,6 +6104,11 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hook-form@^7.47.0:
+  version "7.47.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.47.0.tgz#a42f07266bd297ddf1f914f08f4b5f9783262f31"
+  integrity sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -6052,6 +6258,14 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+resend@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-1.1.0.tgz#b7170339fde1257b6550b65bfc5373fb51b90ca3"
+  integrity sha512-it8TIDVT+/gAiJsUlv2tdHuvzwCCv4Zwu+udDqIm/dIuByQwe68TtFDcPccxqpSVVrNCBxxXLzsdT1tsV+P3GA==
+  dependencies:
+    "@react-email/render" "0.0.7"
+    type-fest "3.13.0"
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz"
@@ -6150,6 +6364,13 @@ scheduler@^0.23.0:
   integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
+
+selderee@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/selderee/-/selderee-0.10.0.tgz#ec83d6044d9026668dc9bd2561acfde99a4e3a1c"
+  integrity sha512-DEL/RW/f4qLw/NrVg97xKaEBC8IpzIG2fvxnzCp3Z4yk4jQ3MXom+Imav9wApjxX2dfS3eW7x0DXafJr85i39A==
+  dependencies:
+    parseley "^0.11.0"
 
 semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -6566,6 +6787,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.13.0.tgz#b088347ae73779a750c461694b264340c4c8c0d7"
+  integrity sha512-Gur3yQGM9qiLNs0KPP7LPgeRbio2QTt4xXouobMCarR0/wyW3F+F/+OWwshg3NG0Adon7uQfSZBpB46NfhoF1A==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
# Adding a contact form

## Features
+ Added contact form with server side and front-end validation
+ Updated mixit.fm DNS records to receive emails using [Resend](https://resend.com/)
+ Footer in the contact page for mobile devices now displays extra contact links instead of a contact form
 
##  👀 Preview

<details>
  <summary>

### Contact form preview on desktop
  </summary>


#### Desktop 
![localhost_3000_contact](https://github.com/mianjoto/mixit/assets/78712025/c3650628-3d71-400e-a37d-fa909f08b3b5)

</details>

<details>
  <summary>

### Contact form preview on mobile
  </summary>


#### Mobile
![localhost_3000_contact(iPhone 12 Pro)](https://github.com/mianjoto/mixit/assets/78712025/4487de2d-8328-4bd9-ac2d-bead87e68c34)

#### Mobile - Extra contact links shown in `/contact` route
![localhost_3000_contact(iPhone 12 Pro) (1)](https://github.com/mianjoto/mixit/assets/78712025/6f413648-5623-45b5-adf7-2506730eef17)

</details>

