### PR TITLE
Add 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Footer from "@/components/footer";
+import { LandingNavbar } from "@/components/landing-navbar";
+import NotFoundSection from "@/components/not-found-section";
+
+export default function NotFound() {
+  return (
+    <>
+      <LandingNavbar />
+      <NotFoundSection />
+      <Footer />
+    </>
+  );
+}

--- a/src/components/disc.tsx
+++ b/src/components/disc.tsx
@@ -3,15 +3,23 @@ import { cn } from "../../lib/utils";
 import { VariantProps, cva } from "class-variance-authority";
 import { FC } from "react";
 
+export type RingColors =
+  | "primary"
+  | "accent-1"
+  | "accent-2"
+  | "accent-3"
+  | "accent-4"
+  | "accent-5";
+
 const discVariants = cva("-z-10", {
   variants: {
     ringColor: {
-      primary: "text-primary",
-      "accent-1": "text-accent-1",
-      "accent-2": "text-accent-2",
-      "accent-3": "text-accent-3",
-      "accent-4": "text-accent-4",
-      "accent-5": "text-accent-5",
+      ["primary" as RingColors]: "text-primary",
+      ["accent-1" as RingColors]: "text-accent-1",
+      ["accent-2" as RingColors]: "text-accent-2",
+      ["accent-3" as RingColors]: "text-accent-3",
+      ["accent-4" as RingColors]: "text-accent-4",
+      ["accent-5" as RingColors]: "text-accent-5",
     },
     spin: {
       clockwise: "motion-safe:animate-disc-spin-cw",

--- a/src/components/not-found-section.tsx
+++ b/src/components/not-found-section.tsx
@@ -1,0 +1,61 @@
+import { NavbarHeight } from "@/data/objects/navbar-data";
+import { Section } from "./ui/section";
+import { HeadingLevels } from "@/types/text";
+import { Heading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import { getRandomFrom } from "../../lib/utils";
+import { NotFoundMessages } from "@/data/json";
+import { Button } from "./ui/button";
+import { Disc, RingColors } from "./disc";
+
+const NotFoundSection = () => {
+  const exclamationText = getRandomFrom(NotFoundMessages.exclamations);
+  const descriptionText = getRandomFrom(NotFoundMessages.descriptions);
+  const randomRingColor = getRandomFrom([
+    "primary",
+    "accent-1",
+    "accent-2",
+    "accent-3",
+    "accent-4",
+    "accent-5",
+  ]);
+  return (
+    <>
+      <Section
+        padding
+        fitScreenHeight
+        compensateForFooter
+        className="mx-auto grid place-items-center items-center gap-32 md:grid-flow-col md:grid-cols-[1.3fr_2.2fr] md:grid-rows-1 md:place-items-center"
+      >
+        <Disc
+          ringColor={randomRingColor as RingColors}
+          spin="clockwise"
+          className="relative top-[5%] hidden h-auto justify-self-center md:block md:w-[150%]"
+        />
+        <Section
+          level="main"
+          className={
+            "flex flex-col place-content-center items-center gap-56 overflow-hidden"
+          }
+        >
+          <header className="flex flex-col gap-16">
+            <Heading
+              level={HeadingLevels.h1}
+              alignment="center"
+              textColor="primary"
+            >
+              {exclamationText}
+            </Heading>
+            <Text alignment="center">{descriptionText}</Text>
+          </header>
+
+          <Button href="/" size="cta">
+            Return home
+          </Button>
+        </Section>
+      </Section>
+    </>
+  );
+};
+
+export default NotFoundSection;

--- a/src/data/json/index.ts
+++ b/src/data/json/index.ts
@@ -1,1 +1,2 @@
 export { default as InDevelopmentMessages } from "./in-development-messages.json";
+export { default as NotFoundMessages } from "./not-found-messages.json";

--- a/src/data/json/not-found-messages.json
+++ b/src/data/json/not-found-messages.json
@@ -1,0 +1,20 @@
+{
+  "exclamations": [
+    "Yikes...",
+    "Whoops...",
+    "Sorry...",
+    "Oops!",
+    "Weird...",
+    "Hmmm..."
+  ],
+  "descriptions": [
+    "We couldn't find that page. Did we mix too hard?",
+    "Looks like we couldn't find that page.",
+    "That page is nowhere to be found. Did we blend too much?",
+    "We couldn't find that page. Too much mixing?",
+    "We couldn't find that page...",
+    "We can't seem to locate the page you're looking for.",
+    "The page you're trying to access does not exist.",
+    "Can't find that page. Did you shuffle too much?"
+  ]
+}


### PR DESCRIPTION
# Adding 404 page

## Features
+ Add 404 page
+ Randomized exclamation
+ Randomized description
+ Randomized disc ring color 
+ Disc hides on mobile devices
 
## 👀 Preview

<details>
  <summary>

### 404 Preview on Various Devices

  </summary>

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
Desktop| 1440x1020 | ![localhost_3000_404](https://github.com/mianjoto/mixit/assets/78712025/63c5bdd6-708a-4d6f-9635-5cf2a5fc6ca5)
iPhone 12 Pro | 390x844 | ![localhost_3000_404(iPhone 12 Pro)](https://github.com/mianjoto/mixit/assets/78712025/2381d4ae-7dd9-4b53-8cfc-85df98b174d1)
iPad Air (Portrait) | 820x1180 | ![localhost_3000_404(iPad Air)](https://github.com/mianjoto/mixit/assets/78712025/a2fc4769-9e03-40a2-b7ec-c5f584914c90)
iPad Air (Landscape) | 1180x820 | ![localhost_3000_404(iPad Air) (1)](https://github.com/mianjoto/mixit/assets/78712025/0c4a9aaf-a39a-4cb6-b22c-40e2a457d644)

</details>

## Development notes

<details>
  <summary>The following "exclamations" have an equal change to appear on visit:</summary>

+ "Yikes..."
+ "Whoops..."
+ "Sorry..."
+ "Oops!"
+ "Weird..."
+ "Hmmm...

</details>

<details>
  <summary>The following "descriptions" have an equal change to appear on visit:</summary>

+ "We couldn't find that page. Did we mix too hard?"
+ "Looks like we couldn't find that page."
+ "That page is nowhere to be found. Did we blend too much?"
+ "We couldn't find that page. Too much mixing?"
+ "We couldn't find that page..."
+ "We can't seem to locate the page you're looking for."
+ "The page you're trying to access does not exist."
+ "Can't find that page. Did you shuffle too much?

</details>