### PR TITLE
Persist selected playlist with new search queries

### DIFF
--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
 import { Session } from "next-auth";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import { getSearchResults } from "../../lib/spotify-query";
 import { DashboardHeading } from "./dashboard";
 import { DashboardShelf } from "./dashboard-shelf";
@@ -10,8 +10,11 @@ import { useDebounce } from "@uidotdev/usehooks";
 import { SearchInput } from "./ui/search-input";
 import { Apps } from "@/types/apps";
 import { Playlist } from "@/types/spotify";
-import { ShuffleInput } from "@/types/mixit";
-import { SelectedPlaylistType } from "@/contexts/selected-playlist-context";
+import { ShuffleInput, ShuffleInputType, ShuffleOption } from "@/types/mixit";
+import SelectedPlaylistContext, {
+  SelectedPlaylistContextType,
+  SelectedPlaylistType,
+} from "@/contexts/selected-playlist-context";
 
 type AppFormPlaylistSearchProps = {
   session: Session;
@@ -28,6 +31,9 @@ export function AppFormPlaylistSearch({
 }: AppFormPlaylistSearchProps) {
   const [query, setQuery] = useState<string | null>(null);
   const debouncedQuery = useDebounce(query, 250);
+  const { selectedPlaylist } = useContext(
+    SelectedPlaylistContext
+  ) as SelectedPlaylistContextType;
 
   function handleSearch(event: ChangeEvent<HTMLInputElement>): void {
     setQuery(event.currentTarget.value);
@@ -40,32 +46,30 @@ export function AppFormPlaylistSearch({
     staleTime: 5 * 60 * 1000,
   });
 
-  let renderedResults;
-  if (
-    populateWithPlaylist &&
-    (shuffleInput.type === "user-playlists" ||
-      shuffleInput.type === "all-playlists")
-  ) {
-    renderedResults = renderPlaylist(populateWithPlaylist as Playlist, app);
+  function getRenderedResults() {
+    if (
+      populateWithPlaylist &&
+      [
+        "user-playlists" as ShuffleInputType,
+        "all-playlists" as ShuffleInputType,
+      ].includes(shuffleInput.type as ShuffleInputType)
+    ) {
+      return renderPlaylist(populateWithPlaylist as Playlist, app);
+    } else if (!searchResults || !searchResults.items) {
+      return shuffleInput.playlist
+        ? renderPlaylist(shuffleInput.playlist as Playlist, app)
+        : null;
+    } else {
+      return renderSearchResults(
+        searchResults,
+        selectedPlaylist as Playlist,
+        query,
+        app
+      );
+    }
   }
 
-  if (!searchResults || !searchResults.items) {
-    if (shuffleInput.playlist) {
-      renderedResults = renderPlaylist(shuffleInput.playlist as Playlist, app);
-    } else {
-      renderedResults = null;
-    }
-  } else {
-    if (searchResults.total > 0) {
-      renderedResults = searchResults?.items.map((playlist) =>
-        renderPlaylist(playlist as Playlist, app)
-      );
-    } else {
-      renderedResults = (
-        <p className="text-body">No results found for "{query}"</p>
-      );
-    }
-  }
+  let renderedResults = getRenderedResults();
 
   return (
     <section className="flex flex-col gap-16">
@@ -94,4 +98,36 @@ function renderPlaylist(playlist: Playlist, app: Apps) {
       app={app}
     />
   );
+}
+
+function renderSearchResults(
+  searchResults:
+    | SpotifyApi.PagingObject<SpotifyApi.PlaylistObjectSimplified>
+    | undefined,
+  selectedPlaylist: Playlist | null,
+  query: string | null,
+  app: Apps
+) {
+  if (searchResults === undefined) {
+    return (
+      <p className="text-body">
+        No results found... Try searching for something new.
+      </p>
+    );
+  }
+
+  if (searchResults.total === 0) {
+    return <p className="text-body">No results found for "{query}"</p>;
+  }
+
+  let playlists = searchResults.items;
+
+  // If a playlist has been selected, show it first before any query result
+  if (selectedPlaylist !== null) {
+    playlists = playlists.filter((playlist) => playlist !== selectedPlaylist);
+
+    playlists.unshift(selectedPlaylist as Playlist);
+  }
+
+  return playlists.map((playlist) => renderPlaylist(playlist as Playlist, app));
 }


### PR DESCRIPTION
# Search input quality of life
### The selected playlist now persists when you change your search query, and only becomes discarded when you select a new playlist from the new query.


##  👀 Preview

<details>
  <summary>

### Selected playlist persistence preview
  </summary>

When you select a playlist, for example, a Hip Hop Mix playlist by Spotify...
![image](https://github.com/mianjoto/mixit/assets/78712025/eca1ba04-923a-4d6e-b969-194b1c4260e6)

And search something else, like "classical music," the selected Hip Hop Mix playlist from before remains selected, even though it wouldn't be included in the search query.
![image](https://github.com/mianjoto/mixit/assets/78712025/2c3f4906-03c5-4f41-b427-61722293ed8e)
 

</details>

## Development notes
This feature was added due to user testing and feedback. Users felt frustrated when they selected a playlist, searched for another playlist, and "lost" the previously selected playlist. This fixes the previous visual bug where playlists would appear darker after selecting a playlist and changing your search query, since this new feature keeps the selected playlist in the user's view to let the user know that the playlist has been selected.