### PR TITLE
Add include explicit songs option

### DIFF
--- a/lib/mixit-apps.ts
+++ b/lib/mixit-apps.ts
@@ -2,12 +2,14 @@ import { MixitInput, ShuffleOption } from "@/types/mixit";
 import { Playlist } from "@/types/spotify";
 import {
   createPlaylistAndPopulateWithTracks,
-  getCurrentUser,
-  getLikedSongsAsPlaylist,
   replaceTracksInPlaylist,
 } from "./spotify-query";
 import { Session } from "next-auth";
-import { fisherYatesShuffle, getRandomSongsFromPlaylist } from "./mixit";
+import {
+  fisherYatesShuffle,
+  getRandomSongsFromPlaylist,
+  getLikedSongsAsPlaylist,
+} from "./mixit";
 
 type useShufflerAppParams = {
   data: MixitInput;
@@ -23,8 +25,9 @@ export async function useShufflerApp({
   (SpotifyApi.CreatePlaylistResponse | undefined) | string
 > {
   let playlist;
+
   if (data.input.type === "liked-songs") {
-    playlist = await getLikedSongsAsPlaylist(session);
+    playlist = await getLikedSongsAsPlaylist(session, shuffleOptions);
   } else {
     playlist = data.input.playlist as Playlist;
   }

--- a/lib/mixit-apps.ts
+++ b/lib/mixit-apps.ts
@@ -27,7 +27,7 @@ export async function useShufflerApp({
   let playlist;
 
   if (data.input.type === "liked-songs") {
-    playlist = await getLikedSongsAsPlaylist(session, shuffleOptions);
+    playlist = await getLikedSongsAsPlaylist(session);
   } else {
     playlist = data.input.playlist as Playlist;
   }

--- a/lib/mixit.ts
+++ b/lib/mixit.ts
@@ -1,4 +1,4 @@
-import { Playlist } from "@/types/spotify";
+import { LikedSongsPlaylist, Playlist } from "@/types/spotify";
 import SpotifyWebApi from "spotify-web-api-node";
 import {
   MAX_PLAYLIST_LENGTH,
@@ -64,6 +64,42 @@ async function lazyWindowRandomSongs(
   );
 
   return selectedSongUris;
+}
+
+export async function getLikedSongsAsPlaylist(
+  session: Session,
+  options: ShuffleOption[]
+): Promise<LikedSongsPlaylist> {
+  if (!session) {
+    signIn("spotify");
+    return Promise.reject("No session");
+  }
+
+  const spotify = getSpotifyApi(session);
+
+  // Get the first song so something is requested
+  const likedSongResponse = await spotify.getMySavedTracks();
+  const likedSongs = likedSongResponse.body.items;
+
+  if (likedSongResponse.statusCode !== 200) {
+    Promise.reject("Error getting user");
+  }
+
+  const userId = (await spotify.getMe()).body.id;
+  const totalLikedSongs = likedSongResponse.body.total;
+
+  const likedSongsPlaylist = {
+    name: "Liked Songs",
+    id: "liked-songs-id",
+    userId: userId,
+    tracks: {
+      href: "https://api.spotify.com/v1/me/tracks",
+      total: totalLikedSongs,
+      items: likedSongs,
+    },
+  } as LikedSongsPlaylist;
+
+  return likedSongsPlaylist;
 }
 
 export function getLazyWindowPaginationOptions(

--- a/lib/spotify-query.ts
+++ b/lib/spotify-query.ts
@@ -121,9 +121,7 @@ export async function getTracksSliceFromPlaylist(
       Promise.reject("Failed to get tracks from Liked Songs playlist");
     }
 
-    return likedSongsResponse.body.items.map(
-      (track) => track?.track?.uri as string
-    ) as unknown as string[];
+    return likedSongsResponse.body.items.map((track) => track.track);
   }
 
   // If normal playlist, return tracks as normal
@@ -136,9 +134,7 @@ export async function getTracksSliceFromPlaylist(
     Promise.reject("Failed to get tracks from playlist");
   }
 
-  return tracksResponse.body.items.map(
-    (track) => track?.track?.uri as string
-  ) as unknown as string[];
+  return tracksResponse.body.items.map((track) => track.track);
 }
 
 type AddTracksToPlaylistOptions = {

--- a/lib/spotify-query.ts
+++ b/lib/spotify-query.ts
@@ -174,7 +174,9 @@ export async function createPlaylistAndPopulateWithTracks(
   session: Session
 ) {
   if (trackUris.length === 0) {
-    Promise.reject("Did not receive any tracks to create the new playlist");
+    return Promise.reject(
+      "Did not receive any tracks to create the new playlist"
+    );
   }
 
   if (!session) {

--- a/lib/spotify-query.ts
+++ b/lib/spotify-query.ts
@@ -94,41 +94,6 @@ export async function getCurrentUser({
 
 export const MAX_REQUESTS_FOR_LIKED_SONGS = 10;
 
-export async function getLikedSongsAsPlaylist(
-  session: Session
-): Promise<LikedSongsPlaylist> {
-  if (!session) {
-    signIn("spotify");
-    return Promise.reject("No session");
-  }
-
-  const spotify = getSpotifyApi(session);
-
-  // Get the first song so something is requested
-  const likedSongResponse = await spotify.getMySavedTracks();
-  const likedSongs = likedSongResponse.body.items;
-
-  if (likedSongResponse.statusCode !== 200) {
-    Promise.reject("Error getting user");
-  }
-
-  const userId = (await spotifyApi.getMe()).body.id;
-  const totalLikedSongs = likedSongResponse.body.total;
-
-  const likedSongsPlaylist = {
-    name: "Liked Songs",
-    id: "liked-songs-id",
-    userId: userId,
-    tracks: {
-      href: "https://api.spotify.com/v1/me/tracks",
-      total: totalLikedSongs,
-      items: likedSongs,
-    },
-  } as LikedSongsPlaylist;
-
-  return likedSongsPlaylist;
-}
-
 export const MAX_PLAYLIST_LENGTH = 100;
 export const MAX_SONGS_PER_REQUEST = 50;
 

--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -120,14 +120,17 @@ function renderSearchResults(
     return <p className="text-body">No results found for "{query}"</p>;
   }
 
-  let playlists = searchResults.items;
-
   // If a playlist has been selected, show it first before any query result
   if (selectedPlaylist !== null) {
-    playlists = playlists.filter((playlist) => playlist !== selectedPlaylist);
-
-    playlists.unshift(selectedPlaylist as Playlist);
+    searchResults.items = [
+      selectedPlaylist,
+      ...searchResults.items.filter(
+        (playlist) => playlist !== selectedPlaylist
+      ),
+    ];
   }
 
-  return playlists.map((playlist) => renderPlaylist(playlist as Playlist, app));
+  return searchResults.items.map((playlist) =>
+    renderPlaylist(playlist as Playlist, app)
+  );
 }

--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -120,8 +120,11 @@ function renderSearchResults(
     return <p className="text-body">No results found for "{query}"</p>;
   }
 
-  // If a playlist has been selected, show it first before any query result
-  if (selectedPlaylist !== null) {
+  // If a playlist has been selected and the user is changing the query, show the playlist first before any query result
+  if (
+    selectedPlaylist !== null &&
+    !searchResults.items.includes(selectedPlaylist)
+  ) {
     searchResults.items = [
       selectedPlaylist,
       ...searchResults.items.filter(

--- a/src/components/app-form-playlist-search.tsx
+++ b/src/components/app-form-playlist-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
 import { Session } from "next-auth";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import { getSearchResults } from "../../lib/spotify-query";
 import { DashboardHeading } from "./dashboard";
 import { DashboardShelf } from "./dashboard-shelf";
@@ -10,8 +10,11 @@ import { useDebounce } from "@uidotdev/usehooks";
 import { SearchInput } from "./ui/search-input";
 import { Apps } from "@/types/apps";
 import { Playlist } from "@/types/spotify";
-import { ShuffleInput } from "@/types/mixit";
-import { SelectedPlaylistType } from "@/contexts/selected-playlist-context";
+import { ShuffleInput, ShuffleInputType, ShuffleOption } from "@/types/mixit";
+import SelectedPlaylistContext, {
+  SelectedPlaylistContextType,
+  SelectedPlaylistType,
+} from "@/contexts/selected-playlist-context";
 
 type AppFormPlaylistSearchProps = {
   session: Session;
@@ -28,6 +31,9 @@ export function AppFormPlaylistSearch({
 }: AppFormPlaylistSearchProps) {
   const [query, setQuery] = useState<string | null>(null);
   const debouncedQuery = useDebounce(query, 250);
+  const { selectedPlaylist } = useContext(
+    SelectedPlaylistContext
+  ) as SelectedPlaylistContextType;
 
   function handleSearch(event: ChangeEvent<HTMLInputElement>): void {
     setQuery(event.currentTarget.value);
@@ -40,32 +46,30 @@ export function AppFormPlaylistSearch({
     staleTime: 5 * 60 * 1000,
   });
 
-  let renderedResults;
-  if (
-    populateWithPlaylist &&
-    (shuffleInput.type === "user-playlists" ||
-      shuffleInput.type === "all-playlists")
-  ) {
-    renderedResults = renderPlaylist(populateWithPlaylist as Playlist, app);
+  function getRenderedResults() {
+    if (
+      populateWithPlaylist &&
+      [
+        "user-playlists" as ShuffleInputType,
+        "all-playlists" as ShuffleInputType,
+      ].includes(shuffleInput.type as ShuffleInputType)
+    ) {
+      return renderPlaylist(populateWithPlaylist as Playlist, app);
+    } else if (!searchResults || !searchResults.items) {
+      return shuffleInput.playlist
+        ? renderPlaylist(shuffleInput.playlist as Playlist, app)
+        : null;
+    } else {
+      return renderSearchResults(
+        searchResults,
+        selectedPlaylist as Playlist,
+        query,
+        app
+      );
+    }
   }
 
-  if (!searchResults || !searchResults.items) {
-    if (shuffleInput.playlist) {
-      renderedResults = renderPlaylist(shuffleInput.playlist as Playlist, app);
-    } else {
-      renderedResults = null;
-    }
-  } else {
-    if (searchResults.total > 0) {
-      renderedResults = searchResults?.items.map((playlist) =>
-        renderPlaylist(playlist as Playlist, app)
-      );
-    } else {
-      renderedResults = (
-        <p className="text-body">No results found for "{query}"</p>
-      );
-    }
-  }
+  let renderedResults = getRenderedResults();
 
   return (
     <section className="flex flex-col gap-16">
@@ -94,4 +98,36 @@ function renderPlaylist(playlist: Playlist, app: Apps) {
       app={app}
     />
   );
+}
+
+function renderSearchResults(
+  searchResults:
+    | SpotifyApi.PagingObject<SpotifyApi.PlaylistObjectSimplified>
+    | undefined,
+  selectedPlaylist: Playlist | null,
+  query: string | null,
+  app: Apps
+) {
+  if (searchResults === undefined) {
+    return (
+      <p className="text-body">
+        No results found... Try searching for something new.
+      </p>
+    );
+  }
+
+  if (searchResults.total === 0) {
+    return <p className="text-body">No results found for "{query}"</p>;
+  }
+
+  let playlists = searchResults.items;
+
+  // If a playlist has been selected, show it first before any query result
+  if (selectedPlaylist !== null) {
+    playlists = playlists.filter((playlist) => playlist !== selectedPlaylist);
+
+    playlists.unshift(selectedPlaylist as Playlist);
+  }
+
+  return playlists.map((playlist) => renderPlaylist(playlist as Playlist, app));
 }

--- a/src/components/choose-shuffle-settings-and-mix-form.tsx
+++ b/src/components/choose-shuffle-settings-and-mix-form.tsx
@@ -10,6 +10,7 @@ import { Session } from "next-auth";
 import { useOptions } from "@/hooks/useOptions";
 import { useToast } from "@/hooks/useToast";
 import { OpenOnSpotifyToastAction, ToastAction } from "./ui/toast";
+import { IncludeExplicitSongs } from "../data/objects/shuffle-options";
 
 type ChooseShuffleSettingsAndMixProps = {
   app: Apps;
@@ -36,7 +37,10 @@ const ChooseShuffleSettingsAndMix = ({
       return true;
     }
 
-    return option.id !== ShuffleOptions.PreferOlderSongs.id;
+    // Only disable exclusionary options as only shuffling in-place
+    const exclusionaryOptions = [IncludeExplicitSongs];
+
+    return !exclusionaryOptions.includes(option);
   }
 
   const playlistName =

--- a/src/components/choose-shuffle-settings-and-mix-form.tsx
+++ b/src/components/choose-shuffle-settings-and-mix-form.tsx
@@ -67,23 +67,31 @@ const ChooseShuffleSettingsAndMix = ({
     });
   }
 
+  const shuffleSettingsComponent = (
+    <ShuffleSettings
+      app={app}
+      excludeOptionsFn={handleVisibleOptions}
+      enabledOptions={enabledOptions}
+      toggleOption={toggleOption}
+    />
+  );
+
+  const noOptionsAreAvailable = shuffleSettingsComponent === null;
+  const adviceSubheadingText = noOptionsAreAvailable
+    ? `To customize how ${app} mixes your music, try mixing something new such as a friend's playlist or your Daily Mixes.`
+    : `For a custom mix, feel free to change settings about how ${app} mixes
+  your music.`;
+
   return (
     <>
       <section className="flex flex-col gap-20">
         <header className="flex flex-col gap-8">
           <DashboardHeading text="You're ready to mix!" />
           <Text textColor="gray" className="max-w-fit">
-            For a custom mix, feel free to change settings about how {app} mixes
-            your music.
+            {adviceSubheadingText}
           </Text>
         </header>
-
-        <ShuffleSettings
-          app={app}
-          excludeOptionsFn={handleVisibleOptions}
-          enabledOptions={enabledOptions}
-          toggleOption={toggleOption}
-        />
+        {shuffleSettingsComponent}
       </section>
       <Button size="default" willRedirect={false} onClick={handleSubmitButton}>
         Mix now

--- a/src/data/objects/shuffle-options.ts
+++ b/src/data/objects/shuffle-options.ts
@@ -12,7 +12,13 @@ export const PreferOlderSongs = {
   defaultEnabled: true,
 } as ShuffleOption;
 
-const Shuffler: ShuffleOption[] = [PreferOlderSongs];
+export const IncludeExplicitSongs = {
+  id: "include-explicit-songs",
+  description: "Include explicit songs",
+  defaultEnabled: true,
+} as ShuffleOption;
+
+const Shuffler: ShuffleOption[] = [PreferOlderSongs, IncludeExplicitSongs];
 
 const Blender: ShuffleOption[] = [
   {

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -2,6 +2,7 @@
  * Type aliases for the various Spotify API objects
  */
 export type Playlist = SpotifyApi.PlaylistObjectFull;
+export type Track = SpotifyApi.TrackObjectFull;
 
 /**
  * The ID for the user's liked songs playlist.


### PR DESCRIPTION
# Add include explicit songs option
Can now exclude explicit songs if desired, along with some playlist search improvements (see #24).


##  👀 Preview

<details>
  <summary>

### New "Include explicit songs" option
  </summary>

![localhost_3000_shuffler (3)](https://github.com/mianjoto/mixit/assets/78712025/f635ec9f-6a23-4544-82ce-b9e70945d10b)

</details>

## Development notes
This feature was added due to user testing and feedback. Some potential use cases for this can be if a user wanted to mix a playlist to use play in a classroom or workplace environment, where explicit content may be prohibited.