### PR TITLE
Add mixit is private modal

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -122,3 +122,10 @@ const getUrl = (path: string) => {
 };
 
 export default getUrl;
+
+const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
+export function moreThanOneDayAgo(otherTime: number): boolean {
+  const currentTime = Date.now();
+  return currentTime - otherTime > MILLISECONDS_IN_A_DAY;
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/base": "^5.0.0-beta.13",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.3",
+    "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-form": "^0.0.3",
     "@radix-ui/react-hover-card": "^1.0.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import ReactQueryProvider from "@/providers/react-query-provider";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Toaster } from "@/components/ui/toaster";
 import SelectedPlaylistProvider from "@/providers/selected-playlist-provider";
+import VisitEventHandler from "@/components/visit-event-handler";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
@@ -22,6 +23,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <ReactQueryProvider>
         <SelectedPlaylistProvider>
           <ModalProvider />
+          <VisitEventHandler />
           <body
             className={`${notoSans.className}
           w-screen overflow-x-hidden overscroll-none bg-background`}

--- a/src/components/early-access-info-modal.tsx
+++ b/src/components/early-access-info-modal.tsx
@@ -47,7 +47,7 @@ const EarlyAccessInfoModal = () => {
       onChange={onChange}
       titleClassName={"text-left"}
     >
-      <section className="mt-16 flex flex-col gap-[48px]">
+      <section className="mt-8 flex flex-col gap-[48px] md:mt-16">
         <div className="flex flex-col gap-16">
           <p className="text-base text-body">
             Hello there! Mixit is in private development. Access to Mixit's

--- a/src/components/early-access-info-modal.tsx
+++ b/src/components/early-access-info-modal.tsx
@@ -1,18 +1,43 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Modal from "./modal";
 import useEarlyAccessInfoModal from "@/hooks/useEarlyAccessInfoModal";
 import Link from "next/link";
+import { Button } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+import useToggle from "@/hooks/useToggle";
+
+const DO_NOT_SHOW_INPUT_ID = "do-not-show-early-access-info-modal-again";
 
 const EarlyAccessInfoModal = () => {
+  const { getItem: getDoNotShowValue, setItem: setDoNotShowValue } =
+    useLocalStorage(DO_NOT_SHOW_INPUT_ID);
   const { onClose, isOpen } = useEarlyAccessInfoModal();
+  const { isChecked, toggleCheck } = useToggle();
 
   const onChange = (open: boolean) => {
     if (!open) {
       onClose();
     }
   };
+
+  function handleButtonOnClick() {
+    if (getDoNotShowValue() === true) {
+      return;
+    }
+
+    if (isChecked) {
+      setDoNotShowValue(true);
+    }
+
+    onClose();
+  }
+
+  if (getDoNotShowValue()) {
+    return null;
+  }
 
   return (
     <Modal
@@ -22,7 +47,7 @@ const EarlyAccessInfoModal = () => {
       onChange={onChange}
       titleClassName={"text-left"}
     >
-      <section className="mt-16 flex flex-col gap-32">
+      <section className="mt-16 flex flex-col gap-[48px]">
         <div className="flex flex-col gap-16">
           <p className="text-base text-body">
             Hello there! Mixit is in private development. Access to Mixit's
@@ -32,20 +57,37 @@ const EarlyAccessInfoModal = () => {
           <p className="self-start text-base font-bold text-danger">
             FYI: Logging into Spotify won't work if you're not a tester.
           </p>
+
+          <p className="mt-4 text-sm text-body">
+            If you're interested in being a tester and trying Mixit early, feel
+            free to contact us{" "}
+            <Link
+              href="/contact"
+              className="underline decoration-primary underline-offset-4"
+              onClick={() => onClose()}
+            >
+              here
+            </Link>
+            .
+          </p>
         </div>
 
-        <p className="text-sm text-body">
-          If you're interested in being a tester and trying Mixit early, feel
-          free to contact us{" "}
-          <Link
-            href="/contact"
-            className="underline decoration-primary underline-offset-4"
-            onClick={() => onClose()}
-          >
-            here
-          </Link>
-          .
-        </p>
+        <section className="flex flex-col-reverse items-center gap-16 md:w-fit md:flex-row-reverse md:self-end">
+          <Button onClick={handleButtonOnClick}>Sounds good!</Button>
+          <span className="flex flex-row items-center gap-8">
+            <Checkbox
+              id={DO_NOT_SHOW_INPUT_ID}
+              className="h-16 w-16 border-body bg-tertiary data-[state=checked]:border-gray md:h-12 md:w-12"
+              onClick={toggleCheck}
+            />
+            <label
+              htmlFor={DO_NOT_SHOW_INPUT_ID}
+              className="select-none self-end  text-base text-body transition-colors duration-100 peer-data-[state=checked]:text-body md:text-sm md:text-gray"
+            >
+              Don't show this again
+            </label>
+          </span>
+        </section>
       </section>
     </Modal>
   );

--- a/src/components/early-access-info-modal.tsx
+++ b/src/components/early-access-info-modal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import Modal from "./modal";
+import useEarlyAccessInfoModal from "@/hooks/useEarlyAccessInfoModal";
+import Link from "next/link";
+
+const EarlyAccessInfoModal = () => {
+  const { onClose, isOpen } = useEarlyAccessInfoModal();
+
+  const onChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      title="👋 Welcome to Mixit!"
+      description=""
+      isOpen={isOpen()}
+      onChange={onChange}
+      titleClassName={"text-left"}
+    >
+      <section className="mt-16 flex flex-col gap-32">
+        <div className="flex flex-col gap-16">
+          <p className="text-base text-body">
+            Hello there! Mixit is in private development. Access to Mixit's
+            tools is limited to testers for now, but feel free to look around!
+          </p>
+
+          <p className="self-start text-base font-bold text-danger">
+            FYI: Logging into Spotify won't work if you're not a tester.
+          </p>
+        </div>
+
+        <p className="text-sm text-body">
+          If you're interested in being a tester and trying Mixit early, feel
+          free to contact us{" "}
+          <Link
+            href="/contact"
+            className="underline decoration-primary underline-offset-4"
+            onClick={() => onClose()}
+          >
+            here
+          </Link>
+          .
+        </p>
+      </section>
+    </Modal>
+  );
+};
+
+export default EarlyAccessInfoModal;

--- a/src/components/early-access-info-modal.tsx
+++ b/src/components/early-access-info-modal.tsx
@@ -18,7 +18,7 @@ const EarlyAccessInfoModal = () => {
     <Modal
       title="👋 Welcome to Mixit!"
       description=""
-      isOpen={isOpen()}
+      isOpen={isOpen}
       onChange={onChange}
       titleClassName={"text-left"}
     >

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -2,12 +2,15 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Cross1Icon } from "@radix-ui/react-icons";
 import { Heading } from "./ui/heading";
 import { HeadingLevels } from "@/types/text";
+import { cn } from "../../lib/utils";
 
 interface ModalProps {
   isOpen: boolean;
   onChange: (open: boolean) => void;
   title: string;
   description: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
   children: React.ReactNode;
 }
 
@@ -16,6 +19,8 @@ const Modal: React.FC<ModalProps> = ({
   onChange,
   title,
   description,
+  titleClassName,
+  descriptionClassName,
   children,
 }) => {
   return (
@@ -23,12 +28,25 @@ const Modal: React.FC<ModalProps> = ({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
         <Dialog.Content className="fixed left-[50%] top-[50%] z-[100] h-full w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto rounded-md border border-neutral-700 bg-tertiary p-24 drop-shadow-md focus:outline-none md:h-auto md:max-h-[85vh] md:w-[90vw] md:max-w-[700px] md:px-24 md:py-40">
-          <Dialog.Title className="mb-4 transform-gpu text-center text-lg font-bold text-body md:transform-cpu">
+          <Dialog.Title
+            className={cn(
+              "mb-4 transform-gpu text-center text-lg font-bold text-body md:transform-cpu",
+              titleClassName
+            )}
+          >
             {title}
           </Dialog.Title>
-          <Dialog.Description className="mb-5 transform-gpu text-center text-sm leading-normal text-gray md:transform-cpu">
-            {description}
-          </Dialog.Description>
+          {description !== "" ? (
+            <Dialog.Description
+              className={cn(
+                "mb-5 transform-gpu text-center text-sm leading-normal text-gray md:transform-cpu",
+                descriptionClassName
+              )}
+            >
+              {description}
+            </Dialog.Description>
+          ) : null}
+
           <div className="flex transform-gpu flex-col items-center md:transform-cpu">
             {children}
           </div>

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -9,6 +9,7 @@ interface ModalProps {
   onChange: (open: boolean) => void;
   title: string;
   description: string;
+  fullHeight?: boolean;
   titleClassName?: string;
   descriptionClassName?: string;
   children: React.ReactNode;
@@ -19,6 +20,7 @@ const Modal: React.FC<ModalProps> = ({
   onChange,
   title,
   description,
+  fullHeight = false,
   titleClassName,
   descriptionClassName,
   children,
@@ -27,7 +29,12 @@ const Modal: React.FC<ModalProps> = ({
     <Dialog.Root open={isOpen} defaultOpen={isOpen} onOpenChange={onChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
-        <Dialog.Content className="fixed left-[50%] top-[50%] z-[100] h-full w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto rounded-md border border-neutral-700 bg-tertiary p-24 drop-shadow-md focus:outline-none md:h-auto md:max-h-[85vh] md:w-[90vw] md:max-w-[700px] md:px-24 md:py-40">
+        <Dialog.Content
+          className={cn(
+            "fixed left-[50%] top-[50%] z-[100] w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto rounded-md border border-neutral-700 bg-tertiary p-24 pt-40 drop-shadow-md focus:outline-none md:h-auto md:max-h-[85vh] md:w-[90vw] md:max-w-[700px] md:px-24 md:py-40",
+            fullHeight ? "h-full" : "h-fit"
+          )}
+        >
           <Dialog.Title
             className={cn(
               "mb-4 transform-gpu text-center text-lg font-bold text-body md:transform-cpu",

--- a/src/components/select-app-modal.tsx
+++ b/src/components/select-app-modal.tsx
@@ -52,6 +52,7 @@ const SelectAppModal = () => {
       description="Select an app or listen on Spotify"
       isOpen={true}
       onChange={onChange}
+      fullHeight
     >
       <article className="flex w-3/4 flex-col items-center gap-24 md:w-auto md:flex-row md:items-start">
         <DashboardCard

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import { cn } from "@/../lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "focus-visible:ring-ring data-[state=checked]:text-primary-foreground peer h-12 w-12 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-12 w-12" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/components/visit-event-handler.tsx
+++ b/src/components/visit-event-handler.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import useLastVisitedAt from "@/hooks/useLastVisitedAt";
+import { useEffect } from "react";
+import { moreThanOneDayAgo } from "../../lib/utils";
+import useEarlyAccessInfoModal from "@/hooks/useEarlyAccessInfoModal";
+
+function VisitEventHandler() {
+  // Component dependencies
+  const { onOpen: openEarlyAccessInfoModal } = useEarlyAccessInfoModal();
+
+  // Operate on events depending on the user's last visited at time before updating
+  const { lastVisitedAtTime, updateLastVisitedAtToNow } = useLastVisitedAt();
+
+  if (lastVisitedAtTime === undefined) {
+    openEarlyAccessInfoModal();
+  }
+
+  if (moreThanOneDayAgo(lastVisitedAtTime)) {
+    openEarlyAccessInfoModal();
+  }
+
+  // Record now as the last time the user has visited
+  useEffect(() => {
+    updateLastVisitedAtToNow();
+  }, []);
+
+  return null;
+}
+
+export default VisitEventHandler;

--- a/src/hooks/useEarlyAccessInfoModal.ts
+++ b/src/hooks/useEarlyAccessInfoModal.ts
@@ -1,30 +1,19 @@
 import { create } from "zustand";
-import { useLocalStorage } from "./useLocalStorage";
-
-export const HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY =
-  "has-viewed-early-access-info-modal";
 
 interface EarlyAccessInfoStore {
-  isOpen: () => boolean;
+  isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
 }
 
-const useEarlyAccessInfoModal = create<EarlyAccessInfoStore>((set) => ({
-  isOpen: () => {
-    const { getItem } = useLocalStorage(
-      HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY
-    );
-    return getItem() === undefined;
-  },
-  onOpen: () => set({ isOpen: () => true }),
-  onClose: () => {
-    set({ isOpen: () => false });
-    const { setItem } = useLocalStorage(
-      HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY
-    );
-    setItem(true);
-  },
-}));
+const useEarlyAccessInfoModal = create<EarlyAccessInfoStore>(function (set) {
+  return {
+    isOpen: false,
+    onOpen: () => set({ isOpen: true }),
+    onClose: () => {
+      set({ isOpen: false });
+    },
+  };
+});
 
 export default useEarlyAccessInfoModal;

--- a/src/hooks/useEarlyAccessInfoModal.ts
+++ b/src/hooks/useEarlyAccessInfoModal.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { useLocalStorage } from "./useLocalStorage";
+
+export const HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY =
+  "has-viewed-early-access-info-modal";
+
+interface EarlyAccessInfoStore {
+  isOpen: () => boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+const useEarlyAccessInfoModal = create<EarlyAccessInfoStore>((set) => ({
+  isOpen: () => {
+    const { getItem } = useLocalStorage(
+      HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY
+    );
+    return getItem() === undefined;
+  },
+  onOpen: () => set({ isOpen: () => true }),
+  onClose: () => {
+    set({ isOpen: () => false });
+    const { setItem } = useLocalStorage(
+      HAS_VIEWED_EARLY_ACCESS_INFO_STORAGE_KEY
+    );
+    setItem(true);
+  },
+}));
+
+export default useEarlyAccessInfoModal;

--- a/src/hooks/useLastVisitedAt.ts
+++ b/src/hooks/useLastVisitedAt.ts
@@ -1,0 +1,15 @@
+import { useLocalStorage } from "./useLocalStorage";
+
+export const LAST_VISITED_AT_KEY = "last-visited-at";
+
+export default function useLastVisitedAt() {
+  const { getItem, setItem } = useLocalStorage(LAST_VISITED_AT_KEY);
+
+  const updateLastVisitedAtToNow = () => setItem(Date.now());
+  const lastVisitedAtTime = getItem() as number;
+
+  return {
+    lastVisitedAtTime,
+    updateLastVisitedAtToNow,
+  };
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,33 @@
+export const useLocalStorage = (key: string) => {
+  const setItem = (value: unknown) => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (error) {
+      console.log(error);
+      return error;
+    }
+  };
+
+  const getItem = () => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : undefined;
+    } catch (error) {
+      console.log(error);
+      return error;
+    }
+  };
+
+  const removeItem = () => {
+    try {
+      window.localStorage.removeItem(key);
+      return true;
+    } catch (error) {
+      console.log(error);
+      return error;
+    }
+  };
+
+  return { setItem, getItem, removeItem };
+};

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,8 +1,12 @@
+"use client";
+
 export const useLocalStorage = (key: string) => {
   const setItem = (value: unknown) => {
     try {
-      window.localStorage.setItem(key, JSON.stringify(value));
-      return true;
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(value));
+        return true;
+      }
     } catch (error) {
       console.log(error);
       return error;
@@ -11,18 +15,24 @@ export const useLocalStorage = (key: string) => {
 
   const getItem = () => {
     try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : undefined;
+      if (typeof window !== "undefined") {
+        const item = window.localStorage.getItem(key);
+        return item ? JSON.parse(item) : undefined;
+      }
     } catch (error) {
-      console.log(error);
-      return error;
+      console.log(
+        `Key ${key} does not exist in localStorage, returning undefined...`
+      );
+      return undefined;
     }
   };
 
   const removeItem = () => {
     try {
-      window.localStorage.removeItem(key);
-      return true;
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(key);
+        return true;
+      }
     } catch (error) {
       console.log(error);
       return error;

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+function useToggle(defaultChecked: boolean = false) {
+  const [isChecked, setIsChecked] = useState(defaultChecked);
+
+  const toggleCheck = () => setIsChecked(!isChecked);
+
+  return { isChecked, toggleCheck };
+}
+
+export default useToggle;

--- a/src/providers/modal-provider.tsx
+++ b/src/providers/modal-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import AuthModal from "@/components/auth-modal";
 import SelectAppModal from "@/components/select-app-modal";
+import EarlyAccessInfoModal from "@/components/early-access-info-modal";
 
 interface ModalProviderProps {}
 
@@ -22,6 +23,7 @@ const ModalProvider: React.FC<ModalProviderProps> = ({}) => {
     <>
       <AuthModal />
       <SelectAppModal />
+      <EarlyAccessInfoModal />
     </>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,7 +33,7 @@ module.exports = {
         gray: "#A1A1A1",
         success: "#a6e707",
         caution: "#dbc217",
-        danger: "#e43446",
+        danger: "#e24e68",
         info: "#08a2f3",
         "spotify-green": "#1DB954",
         "accent-1": "#FF9785",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,6 +1757,21 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-layout-effect" "1.0.1"
 
+"@radix-ui/react-checkbox@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz#98f22c38d5010dd6df4c5744cac74087e3275f4b"
+  integrity sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
 "@radix-ui/react-collapsible@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz#df0e22e7a025439f13f62d4e4a9e92c4a0df5b81"


### PR DESCRIPTION
# Add "Mixit is in private development" modal
A modal popup will now show explaining that the app is not yet public, but you can reach out to be a tester by going to the contact page.

Features:
+ Modal popup shows on first visit to the site
+ Modal will re-appear if user returns to the site after 24 hours
+ Option to not show the modal ever again

This was implemented using the browser's local storage API.

## 👀 Preview

<details>
  <summary>

### In-development modal preview on various devices

  </summary>

| Device | Dimensions (px) | Screenshot |
|--------|--------------------|--------------|
Desktop| 1440x1020 | ![localhost_3000_dashboard (1)](https://github.com/mianjoto/mixit/assets/78712025/c007ee1c-323f-4e04-b6b5-6c11888e1a93)
iPhone 12 Pro | 390x844 | ![localhost_3000_dashboard(iPhone 12 Pro) (1)](https://github.com/mianjoto/mixit/assets/78712025/657563c7-348d-4b5f-adec-95b9441f0601)
iPad Air (Portrait) | 820x1180 | ![localhost_3000_dashboard(iPad Air) (2)](https://github.com/mianjoto/mixit/assets/78712025/a9ff9ccb-91df-433b-b5f5-0f91fc239966)
iPad Air (Landscape) | 1180x820 | ![localhost_3000_dashboard(iPad Air) (3)](https://github.com/mianjoto/mixit/assets/78712025/40ee07ee-82a7-4c75-8b79-86f30c42edb4)



</details>

## Development notes
This branch also developed a component that can determine how long ago a user as used Mixit. All information is stored locally on the user's device, and can be cleared at any time, and is not sent to any databases. Refer to the [VisitEventHandler](https://github.com/mianjoto/mixit/blob/a2812f760bed9a9ce9b130adcfe3f1c4222ea494/src/components/visit-event-handler.tsx) component to see how data is collected and managed.